### PR TITLE
Fixes Chinese language recursion problem with UCultureInfo (Fixes #29)

### DIFF
--- a/src/ICU4N/Support/Globalization/CultureInfoExtensions.cs
+++ b/src/ICU4N/Support/Globalization/CultureInfoExtensions.cs
@@ -13,6 +13,13 @@ namespace ICU4N.Globalization
         private static readonly LurchTable<CultureInfo, UCultureInfo> uCultureInfoCache
             = new LurchTable<CultureInfo, UCultureInfo>(LurchTableOrder.Access, limit: 64, comparer: CultureInfoEqualityComparer.Instance);
 
+        static CultureInfoExtensions()
+        {
+            // ICU4N: We need to ensure the calendar data is loaded before dealing with a Lazy<T> here, as the calendar data requires a call
+            // back to ToUCultureInfo(), which leads to infinite recursion for Chinese cultures that are aliased to lookup calendars.
+            UCultureInfo.DotNetLocaleHelper.EnsureInitialized();
+        }
+
         /// <summary>
         /// <icu/> Returns a <see cref="UCultureInfo"/> object for a <see cref="CultureInfo"/>.
         /// The <see cref="UCultureInfo"/> is canonicalized.

--- a/tests/ICU4N.Tests/Support/Globalization/UCultureInfoTest.cs
+++ b/tests/ICU4N.Tests/Support/Globalization/UCultureInfoTest.cs
@@ -5058,5 +5058,20 @@ namespace ICU4N.Globalization
         //        Assert.AreEqual(expected, actual);
         //    }
         //}
+
+        [Test]
+        [TestCase("zh-TW")]
+        [TestCase("zh-CN")]
+        [TestCase("zh-HK")]
+        [TestCase("zh-MO")]
+        [TestCase("zh-SG")]
+        public void TestChineseCharactersGH29(string cultureName)
+        {
+            // If you're not running Windows in Chinese, set explicitly
+            CurrentCulture = new CultureInfo(cultureName);
+
+            Assert.DoesNotThrow(() => { var _ = UCultureInfo.CurrentCulture; });
+        }
+
     }
 }


### PR DESCRIPTION
See #29.

The problem was due to the fact that some cultures use aliases to store the CLDR data, and in such cases another call to `UResourceBundle.GetBundleInstance()` inside of the first one which causes infinite recursion. The fix was to move the call to lookup default calendars to the static initialization stage and to call `EnsureInitialized()` before attempting to use the extension methods in [`CultureInfoExtensions`](https://github.com/NightOwl888/ICU4N/blob/59c4d01b274524118e751ee5a6ac85824010433b/src/ICU4N/Support/Globalization/CultureInfoExtensions.cs#L22). We loop through all cultures, but only cache the 14 cultures that have a default calendar that is not "gregorian".