### PR TITLE
Added Lazy<T> to make GetOrAdd() calls atomic (Fixes #31)

### DIFF
--- a/src/ICU4N/Impl/CacheValue.cs
+++ b/src/ICU4N/Impl/CacheValue.cs
@@ -115,6 +115,11 @@ namespace ICU4N.Impl
                 this.reference = CreateReference(initialValue);
             }
 
+            ~SoftValue() // ICU4N specific - Added finalizer
+            {
+                syncLock?.Dispose();
+            }
+
             private SoftReference<TValue> CreateReference(TValue value)
             {
 #if FEATURE_MICROSOFT_EXTENSIONS_CACHING

--- a/src/ICU4N/Impl/ICURWLock.cs
+++ b/src/ICU4N/Impl/ICURWLock.cs
@@ -100,6 +100,11 @@ namespace ICU4N.Impl
 
         // ICU4N specific - de-nested Stats and renamed ICUReaderWriterLockStats
 
+        ~ICUReaderWriterLock() // ICU4N specific - Added finalizer
+        {
+            rwl?.Dispose();
+        }
+
         /// <summary>
         /// Reset the stats.  Returns existing stats, if any.
         /// </summary>

--- a/src/ICU4N/Impl/Locale/LocaleObjectCache.cs
+++ b/src/ICU4N/Impl/Locale/LocaleObjectCache.cs
@@ -1,10 +1,11 @@
 ﻿using J2N.Collections.Concurrent;
+using System;
 
 namespace ICU4N.Impl.Locale
 {
     public abstract class LocaleObjectCache<TKey, TValue> where TValue : class
     {
-        private readonly LurchTable<TKey, TValue> _map;
+        private readonly LurchTable<TKey, Lazy<TValue>> _map;
 
         public LocaleObjectCache()
             : this(16)
@@ -16,12 +17,13 @@ namespace ICU4N.Impl.Locale
             // ICU4N: Since .NET doesn't have a memory-sensitive cache, we are using an LRU cache with a fixed size.
             // This ensures that the culture(s) that the application uses most stay near the top of the cache and
             // less used cultures get popped off of the bottom of the cache.
-            _map = new LurchTable<TKey, TValue>(initialCapacity, LurchTableOrder.Access, limit: 64, comparer: null);
+            _map = new LurchTable<TKey, Lazy<TValue>>(initialCapacity, LurchTableOrder.Access, limit: 64, comparer: null);
         }
 
         public virtual TValue Get(TKey key)
         {
-            return _map.GetOrAdd(key, CreateObject);
+            var result = _map.GetOrAdd(key, (key) => new Lazy<TValue>(() => CreateObject(key)));
+            return result.Value;
         }
 
         protected abstract TValue CreateObject(TKey key);

--- a/src/ICU4N/Support/Globalization/CultureInfoExtensions.cs
+++ b/src/ICU4N/Support/Globalization/CultureInfoExtensions.cs
@@ -10,8 +10,8 @@ namespace ICU4N.Globalization
     /// </summary>
     public static class CultureInfoExtensions
     {
-        private static readonly LurchTable<CultureInfo, UCultureInfo> uCultureInfoCache
-            = new LurchTable<CultureInfo, UCultureInfo>(LurchTableOrder.Access, limit: 64, comparer: CultureInfoEqualityComparer.Instance);
+        private static readonly LurchTable<CultureInfo, Lazy<UCultureInfo>> uCultureInfoCache
+            = new LurchTable<CultureInfo, Lazy<UCultureInfo>>(LurchTableOrder.Access, limit: 64, comparer: CultureInfoEqualityComparer.Instance);
 
         /// <summary>
         /// <icu/> Returns a <see cref="UCultureInfo"/> object for a <see cref="CultureInfo"/>.
@@ -27,7 +27,8 @@ namespace ICU4N.Globalization
             //if (culture is UCultureInfo uCulture)
             //    return uCulture;
 
-            return uCultureInfoCache.GetOrAdd(culture, (key) => UCultureInfo.DotNetLocaleHelper.ToUCultureInfo(key));
+            var result = uCultureInfoCache.GetOrAdd(culture, (key) => new Lazy<UCultureInfo>(() => UCultureInfo.DotNetLocaleHelper.ToUCultureInfo(key)));
+            return result.Value;
         }
 
         // ICU4N: For now, we are just comparing using CultureInfo.Equals() as well as comparing


### PR DESCRIPTION
Fixes #31.

In addition, added finalizers to call `ReaderWriterLockSlim.Dispose()` in the appropriate places.