### PR TITLE
PERFORMANCE: ICU4N.Impl.LocaleIDParser: Converted to ref struct using ValueStringBuilder internally to reduce allocations

### DIFF
--- a/src/ICU4N/Impl/ICULocaleService.cs
+++ b/src/ICU4N/Impl/ICULocaleService.cs
@@ -194,7 +194,11 @@ namespace ICU4N.Impl
             else
             {
                 List<T> locales = new List<T>(visIDs.Count);
-                var parser = new LocaleIDParser(string.Empty);
+#if FEATURE_SPAN
+                using var parser = new LocaleIDParser(stackalloc char[16], ReadOnlySpan<char>.Empty);
+#else
+                using var parser = new LocaleIDParser(string.Empty);
+#endif
                 foreach (string id in visIDs)
                 {
                     // Filter the culture type before allocating the object

--- a/src/ICU4N/Impl/Locale/AsciiUtil.cs
+++ b/src/ICU4N/Impl/Locale/AsciiUtil.cs
@@ -1,10 +1,14 @@
-﻿using J2N.Text;
+﻿using ICU4N.Support.Text;
+using J2N.Text;
+using System;
 using System.Text;
 
 namespace ICU4N.Impl.Locale
 {
     public sealed class AsciiUtil
     {
+        private const int CharStackBufferSize = 128;
+
         public static bool CaseIgnoreMatch(string s1, string s2)
         {
             //if (Utility.SameObjects(s1, s2))
@@ -75,7 +79,12 @@ namespace ICU4N.Impl.Locale
             {
                 return s;
             }
+#if FEATURE_SPAN
+            ValueStringBuilder buf = s.Length <= CharStackBufferSize ? new ValueStringBuilder(stackalloc char[s.Length]) : new ValueStringBuilder(s.Length);
+            buf.Append(s.AsSpan(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#else
             StringBuilder buf = new StringBuilder(s.Substring(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#endif
             for (; idx < s.Length; idx++)
             {
                 buf.Append(ToLower(s[idx]));
@@ -98,7 +107,12 @@ namespace ICU4N.Impl.Locale
             {
                 return s;
             }
+#if FEATURE_SPAN
+            ValueStringBuilder buf = s.Length <= CharStackBufferSize ? new ValueStringBuilder(stackalloc char[s.Length]) : new ValueStringBuilder(s.Length);
+            buf.Append(s.AsSpan(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#else
             StringBuilder buf = new StringBuilder(s.Substring(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#endif
             for (; idx < s.Length; idx++)
             {
                 buf.Append(ToUpper(s[idx]));
@@ -128,7 +142,12 @@ namespace ICU4N.Impl.Locale
             {
                 return s;
             }
+#if FEATURE_SPAN
+            ValueStringBuilder buf = s.Length <= CharStackBufferSize ? new ValueStringBuilder(stackalloc char[s.Length]) : new ValueStringBuilder(s.Length);
+            buf.Append(s.AsSpan(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#else
             StringBuilder buf = new StringBuilder(s.Substring(0, idx - 0)); // ICU4N: Checked 2nd parameter
+#endif
             if (idx == 0)
             {
                 buf.Append(ToUpper(s[idx]));

--- a/src/ICU4N/Impl/LocaleIDParser.cs
+++ b/src/ICU4N/Impl/LocaleIDParser.cs
@@ -1,9 +1,10 @@
 ﻿using ICU4N.Impl.Locale;
 using ICU4N.Support.Collections;
-using J2N.Collections.Generic.Extensions;
+using ICU4N.Support.Text;
 using J2N.Text;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Text;
 
 namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
@@ -11,12 +12,20 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
     /// <summary>
     /// Utility class to parse and normalize locale ids (including POSIX style)
     /// </summary>
-    public sealed class LocaleIDParser
+#if FEATURE_SPAN
+    public ref struct LocaleIDParser
+#else
+    public sealed class LocaleIDParser : IDisposable
+#endif
     {
         /// <summary>
         /// Char array representing the locale ID.
         /// </summary>
+#if FEATURE_SPAN
+        private ReadOnlySpan<char> id;
+#else
         private char[] id;
+#endif
 
         /// <summary>
         /// Current position in <see cref="id"/> (while parsing).
@@ -26,7 +35,11 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         /// <summary>
         /// Temporary buffer for parsed sections of data.
         /// </summary>
+#if FEATURE_SPAN
+        private ValueStringBuilder buffer;
+#else
         private StringBuilder buffer;
+#endif
 
         // um, don't handle POSIX ids unless we request it.  why not?  well... because.
         private bool canonicalize;
@@ -34,7 +47,11 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
 
         // used when canonicalizing
         private IDictionary<string, string> keywords;
+#if FEATURE_SPAN
+        private ReadOnlySpan<char> baseName;
+#else
         private string baseName;
+#endif
 
         /// <summary>
         /// Parsing constants.
@@ -47,6 +64,37 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         private const char DOT = '.';
         private const char UNDERSCORE = '_';
 
+#if FEATURE_SPAN
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        public LocaleIDParser(Span<char> initialBuffer, string localeID)
+            : this(initialBuffer, localeID.AsSpan(), false)
+        {
+        }
+
+        public LocaleIDParser(Span<char> initialBuffer, string localeID, bool canonicalize)
+            : this(initialBuffer, localeID.AsSpan(), canonicalize)
+        {
+        }
+#endif
+
+        public LocaleIDParser(Span<char> initialBuffer, ReadOnlySpan<char> localeID)
+            : this(initialBuffer, localeID, false)
+        {
+        }
+
+        public LocaleIDParser(Span<char> initialBuffer, ReadOnlySpan<char> localeID, bool canonicalize)
+        {
+            id = localeID;
+            index = 0;
+            buffer = new ValueStringBuilder(initialBuffer);
+            this.canonicalize = canonicalize;
+            this.hadCountry = false;
+            this.keywords = null;
+            this.baseName = ReadOnlySpan<char>.Empty;
+        }
+#else
+
         public LocaleIDParser(string localeID)
             : this(localeID, false)
         {
@@ -56,6 +104,34 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         {
             Reset(localeID, canonicalize);
         }
+#endif
+
+#if FEATURE_SPAN
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset(string localeID)
+            => Reset(localeID.AsSpan());
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset(string localeID, bool canonicalize)
+            => Reset(localeID.AsSpan(), canonicalize);
+#endif
+
+        public void Reset(ReadOnlySpan<char> localeID)
+        {
+            Reset(localeID, false);
+        }
+
+        public void Reset(ReadOnlySpan<char> localeID, bool canonicalize)
+        {
+            id = localeID;
+            index = 0;
+            buffer.Length = 0;
+            this.canonicalize = canonicalize;
+            this.hadCountry = false;
+        }
+#else
 
         public void Reset(string localeID)
         {
@@ -68,12 +144,18 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             index = 0;
             buffer = new StringBuilder(id.Length + 5);
             this.canonicalize = canonicalize;
+            this.hadCountry = false;
         }
+#endif
 
         private void Reset()
         {
             index = 0;
+#if FEATURE_SPAN
+            buffer.Length = 0;
+#else
             buffer = new StringBuilder(id.Length + 5);
+#endif
         }
 
         // utilities for working on text in the buffer
@@ -96,17 +178,43 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         /// </summary>
         private string GetString(int start)
         {
+#if FEATURE_SPAN
+            return buffer.AsSpan(start).ToString();
+#else
             return buffer.ToString(start, buffer.Length - start);
+#endif
         }
+
+#if FEATURE_SPAN
+        private ReadOnlySpan<char> AsSpan(int start)
+        {
+            return buffer.AsSpan(start);
+        }
+#endif
 
         /// <summary>
         /// Set the length of the buffer to pos, then append the string.
         /// </summary>
+#if FEATURE_SPAN
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void Set(int pos, string s)
+            => Set(pos, s.AsSpan());
+#endif
+
+        private void Set(int pos, ReadOnlySpan<char> s)
+        {
+            buffer.Length = pos;
+            buffer.Insert(pos, s);
+        }
+#else
         private void Set(int pos, string s)
         {
             buffer.Delete(pos, buffer.Length - pos); // ICU4N: Corrected 2nd parameter
             buffer.Insert(pos, s);
         }
+#endif
 
         /// <summary>
         /// Append the string to the buffer.
@@ -115,6 +223,18 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         {
             buffer.Append(s);
         }
+
+#if FEATURE_SPAN
+
+        /// <summary>
+        /// Append the span to the buffer.
+        /// </summary>
+        private void Append(ReadOnlySpan<char> s)
+        {
+            buffer.Append(s);
+        }
+
+#endif
 
         // utilities for parsing text out of the id
 
@@ -234,7 +354,11 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
 
             if (buffer.Length - startLength == 3)
             {
+#if FEATURE_SPAN
+                string lang = LocaleIDs.ThreeToTwoLetterLanguage(AsSpan(0));
+#else
                 string lang = LocaleIDs.ThreeToTwoLetterLanguage(GetString(0));
+#endif
                 if (lang != null)
                 {
                     Set(0, lang);
@@ -295,7 +419,8 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                 if (index - oldIndex != 5)
                 { // +1 to account for separator
                     index = oldIndex;
-                    buffer.Delete(oldBlen, buffer.Length - oldBlen); // ICU4N: Corrected 2nd parameter
+                    //buffer.Delete(oldBlen, buffer.Length - oldBlen); // ICU4N: Corrected 2nd parameter
+                    buffer.Length = oldBlen;
                 }
                 else
                 {
@@ -373,16 +498,22 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                     // their previous values.
                     index = oldIndex;
                     --oldBlen;
-                    buffer.Delete(oldBlen, buffer.Length - oldBlen); // ICU4N: Corrected 2nd parameter
+                    //buffer.Delete(oldBlen, buffer.Length - oldBlen); // ICU4N: Corrected 2nd parameter
+                    buffer.Length = oldBlen;
                     hadCountry = false;
                 }
                 else if (charsAppended == 3)
                 {
+#if FEATURE_SPAN
+                    string region = LocaleIDs.ThreeToTwoLetterRegion(AsSpan(oldBlen));
+#else
                     string region = LocaleIDs.ThreeToTwoLetterRegion(GetString(oldBlen));
+#endif
                     if (region != null)
                     {
                         Set(oldBlen, region);
                     }
+
                 }
 
                 return oldBlen;
@@ -516,6 +647,37 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         // no need for skipvariant, to get the keywords we'll just scan directly for
         // the keyword separator
 
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized language id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's language id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetLanguage(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            ReadOnlySpan<char> result = AsSpan(ParseLanguage());
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized language id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's language id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetLanguage(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            ReadOnlySpan<char> result = AsSpan(ParseLanguage());
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
         /// <summary>
         /// Returns the normalized language id, or the empty string.
         /// </summary>
@@ -524,6 +686,40 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             Reset();
             return GetString(ParseLanguage());
         }
+
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized script id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's script id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetScript(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            ReadOnlySpan<char> result = AsSpan(ParseScript());
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized script id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's script id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetScript(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            ReadOnlySpan<char> result = AsSpan(ParseScript());
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
 
         /// <summary>
         /// Returns the normalized script id, or the empty string.
@@ -535,6 +731,43 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             return GetString(ParseScript());
         }
 
+
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized country id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's country id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetCountry(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            SkipScript();
+            ReadOnlySpan<char> result = AsSpan(ParseCountry());
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized country id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's country id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetCountry(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            SkipScript();
+            ReadOnlySpan<char> result = AsSpan(ParseCountry());
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
+
         /// <summary>
         /// Returns the normalized country id, or the empty string.
         /// </summary>
@@ -545,6 +778,45 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             SkipScript();
             return GetString(ParseCountry());
         }
+
+
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized variant id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's variant id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetVariant(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            SkipScript();
+            SkipCountry();
+            ReadOnlySpan<char> result = AsSpan(ParseVariant());
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized variant id into <paramref name="destination"/>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's variant id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetVariant(Span<char> destination, out int charsWritten)
+        {
+            Reset();
+            SkipLanguage();
+            SkipScript();
+            SkipCountry();
+            ReadOnlySpan<char> result = AsSpan(ParseVariant());
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
 
         /// <summary>
         /// Returns the normalized variant id, or the empty string.
@@ -559,7 +831,7 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         }
 
         /// <summary>
-        /// Returns the language, script, country, and variant as separate strings
+        /// Returns the language id, script id, country id, and variant id as separate strings
         /// in a <see cref="LocaleID"/> structure.
         /// </summary>
         public LocaleID GetLocaleID()
@@ -573,14 +845,29 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             );
         }
 
+#if FEATURE_SPAN
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+
         public void SetBaseName(string baseName)
+            => SetBaseName(baseName.AsSpan());
+#endif
+
+        public void SetBaseName(ReadOnlySpan<char> baseName)
+#else
+        public void SetBaseName(string baseName)
+#endif
         {
             this.baseName = baseName;
         }
 
         public void ParseBaseName(char separator = UNDERSCORE)
         {
+#if FEATURE_SPAN
+            if (!baseName.IsEmpty)
+#else
             if (baseName != null)
+#endif
             {
                 Set(0, baseName);
             }
@@ -611,20 +898,138 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             }
         }
 
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized base form of the locale id to <paramref name="destination"/>.
+        /// The base form does not include keywords.
+        /// <para/>
+        /// Usage Note: The destination may be longer than the locale id. It is recommended to use a buffer
+        /// at least <c>localeID.Length + 10</c>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetBaseName(Span<char> destination, out int charsWritten)
+        {
+            ReadOnlySpan<char> result;
+            if (!baseName.IsEmpty)
+            {
+                result = baseName;
+            }
+            else
+            {
+                ParseBaseName();
+                result = AsSpan(0);
+            }
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized base form of the locale id to <paramref name="destination"/>.
+        /// The base form does not include keywords.
+        /// <para/>
+        /// Usage Note: The destination may be longer than the locale id. It is recommended to use a buffer
+        /// at least <c>localeID.Length + 10</c>.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetBaseName(Span<char> destination, out int charsWritten)
+        {
+            ReadOnlySpan<char> result;
+            if (!baseName.IsEmpty)
+            {
+                result = baseName;
+            }
+            else
+            {
+                ParseBaseName();
+                result = AsSpan(0);
+            }
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+
+        /// <summary>
+        /// Returns the base name as a <see cref="ReadOnlySpan{T}"/>.
+        /// Note this value may be overwritten if another Get or TryGet
+        /// method is called, so it may only be used prior to those operations.
+        /// <para/>
+        /// Despite this limitation, this method allows the use of the base name
+        /// without having to allocate memory first.
+        /// </summary>
+        /// <returns>The base name as a <see cref="ReadOnlySpan{T}"/>.</returns>
+        internal ReadOnlySpan<char> GetBaseNameAsSpan()
+        {
+            if (!baseName.IsEmpty)
+            {
+                return baseName;
+            }
+            ParseBaseName();
+            return AsSpan(0);
+        }
+#endif
+
         /// <summary>
         /// Returns the normalized base form of the locale id.  The base
         /// form does not include keywords.
         /// </summary>
         public string GetBaseName()
         {
+#if FEATURE_SPAN
+            if (!baseName.IsEmpty)
+            {
+                return baseName.ToString();
+            }
+#else
             if (baseName != null)
             {
                 return baseName;
             }
+#endif
             ParseBaseName();
             return GetString(0);
         }
 
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized base form of the locale id using hyphen as the
+        /// separator to <paramref name="destination"/>. This is for compatibility with <see cref="System.Globalization.CultureInfo.Name"/>.
+        /// Does not include keywords.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetName(Span<char> destination, out int charsWritten)
+        {
+            ParseBaseName(HYPHEN);
+            RemoveLeadingSeparator(HYPHEN);
+            ReadOnlySpan<char> result = AsSpan(0);
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized base form of the locale id using hyphen as the
+        /// separator to <paramref name="destination"/>. This is for compatibility with <see cref="System.Globalization.CultureInfo.Name"/>.
+        /// Does not include keywords.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetName(Span<char> destination, out int charsWritten)
+        {
+            ParseBaseName(HYPHEN);
+            RemoveLeadingSeparator(HYPHEN);
+            ReadOnlySpan<char> result = AsSpan(0);
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
         /// <summary>
         /// Returns the normalized base form of the locale id using hyphen as the
         /// separator, for compatibility with <see cref="System.Globalization.CultureInfo.Name"/>.
@@ -632,14 +1037,45 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         /// </summary>
         public string GetName()
         {
-            if (baseName != null)
-            {
-                return baseName;
-            }
             ParseBaseName(HYPHEN);
             RemoveLeadingSeparator(HYPHEN);
             return GetString(0);
         }
+
+#if FEATURE_SPAN
+        /// <summary>
+        /// Copies the normalized full form of the locale id to <paramref name="destination"/>.
+        /// The full form includes keywords if they are present.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's normalized full form of the locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <returns><c>false</c> if <paramref name="destination"/> is not long enough; otherwise, <c>true</c>.</returns>
+        public bool TryGetFullName(Span<char> destination, out int charsWritten)
+        {
+            ParseBaseName();
+            ParseKeywords();
+            ReadOnlySpan<char> result = AsSpan(0);
+            bool success = result.TryCopyTo(destination);
+            charsWritten = success ? result.Length : 0;
+            return success;
+        }
+
+        /// <summary>
+        /// Copies the normalized full form of the locale id to <paramref name="destination"/>.
+        /// The full form includes keywords if they are present.
+        /// </summary>
+        /// <param name="destination">The span in which to write this instance's normalized full form of the locale id as a span of characters.</param>
+        /// <param name="charsWritten">When this method returns, contains the number of characters that were written in <paramref name="destination"/>.</param>
+        /// <exception cref="ArgumentException"><paramref name="destination"/> is too short.</exception>
+        public void GetFullName(Span<char> destination, out int charsWritten)
+        {
+            ParseBaseName();
+            ParseKeywords();
+            ReadOnlySpan<char> result = AsSpan(0);
+            result.CopyTo(destination);
+            charsWritten = result.Length;
+        }
+#endif
 
         /// <summary>
         /// Returns the normalized full form of the locale id.  The full
@@ -706,7 +1142,14 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             {
             }
             --index;
+#if FEATURE_SPAN
+            int bufferLength = index - start;
+            Span<char> buffer = bufferLength <= 64 ? stackalloc char[bufferLength] : new char[bufferLength];
+            int length = id.Slice(start, index - start).Trim().ToLowerInvariant(buffer);
+            return buffer.Slice(0, length).ToString();
+#else
             return AsciiUtil.ToLower(new string(id, start, index - start).Trim());
+#endif
         }
 
         private string GetValue()
@@ -716,7 +1159,11 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             {
             }
             --index;
+#if FEATURE_SPAN
+            return id.Slice(start, index - start).Trim().ToString();
+#else
             return new string(id, start, index - start).Trim(); // leave case alone
+#endif
         }
 
         private static IComparer<string> KeyComparer { get; } = StringComparer.OrdinalIgnoreCase;
@@ -901,6 +1348,14 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                     }
                 }
             }
+        }
+
+        public void Dispose()
+        {
+            // Just for compatibility with ValueStringBuilder (so it can return memory to the array pool)
+#if FEATURE_SPAN
+            buffer.Dispose();
+#endif
         }
     }
 }

--- a/src/ICU4N/Impl/LocaleIDs.cs
+++ b/src/ICU4N/Impl/LocaleIDs.cs
@@ -1,4 +1,8 @@
-﻿namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
+﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
 {
     /// <summary>
     /// Utilities for mapping between old and new language, country, and other
@@ -33,6 +37,7 @@
             return (string[])_languages.Clone();
         }
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
         /// <summary>
         /// Returns a three-letter abbreviation for the provided country.  If the provided
         /// country is empty, returns the empty string.  Otherwise, returns
@@ -41,7 +46,26 @@
         /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
         /// three-letter country abbreviation is not available for this locale.</exception>
         /// <stable>ICU 3.0</stable>
-        public static string GetThreeLetterISOCountryName(string country) // Renamed from GetISO3Country
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetThreeLetterISOCountryName(string country)
+            => GetThreeLetterISOCountryName(country.AsSpan());
+#endif
+
+        /// <summary>
+        /// Returns a three-letter abbreviation for the provided country.  If the provided
+        /// country is empty, returns the empty string.  Otherwise, returns
+        /// an uppercase ISO 3166 3-letter country code.
+        /// </summary>
+        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
+        /// three-letter country abbreviation is not available for this locale.</exception>
+        /// <stable>ICU 3.0</stable>
+        public static string GetThreeLetterISOCountryName(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> country
+#else
+            string country
+#endif
+            ) // Renamed from GetISO3Country
         {
             int offset = FindIndex(_countries, country);
             if (offset >= 0)
@@ -59,6 +83,7 @@
             return "";
         }
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
         /// <summary>
         /// Returns a three-letter abbreviation for the language.  If language is
         /// empty, returns the empty string.  Otherwise, returns
@@ -70,7 +95,29 @@
         /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
         /// three-letter language abbreviation is not available for this locale.</exception>
         /// <stable>ICU 3.0</stable>
-        public static string GetThreeLetterISOLanguageName(string language) // ICU4N: Renamed from GetISO3Language
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetThreeLetterISOLanguageName(string language)
+            => GetThreeLetterISOLanguageName(language.AsSpan());
+#endif
+
+        /// <summary>
+        /// Returns a three-letter abbreviation for the language.  If language is
+        /// empty, returns the empty string.  Otherwise, returns
+        /// a lowercase ISO 639-2/T language code.
+        /// </summary>
+        /// <remarks>The ISO 639-2 language codes can be found on-line at
+        /// <a href="ftp://dkuug.dk/i18n/iso-639-2.txt">ftp://dkuug.dk/i18n/iso-639-2.txt</a>.
+        /// </remarks>
+        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
+        /// three-letter language abbreviation is not available for this locale.</exception>
+        /// <stable>ICU 3.0</stable>
+        public static string GetThreeLetterISOLanguageName(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> language
+#else
+            string language
+#endif
+            ) // ICU4N: Renamed from GetISO3Language
         {
             int offset = FindIndex(_languages, language);
             if (offset >= 0)
@@ -88,7 +135,19 @@
             return "";
         }
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ThreeToTwoLetterLanguage(string lang)
+            => ThreeToTwoLetterLanguage(lang.AsSpan());
+#endif
+
+        public static string ThreeToTwoLetterLanguage(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> lang
+#else
+            string lang
+#endif
+            )
         {
             /* convert 3 character code to 2 character code if possible *CWB*/
             int offset = FindIndex(_languages3, lang);
@@ -106,7 +165,19 @@
             return null;
         }
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string ThreeToTwoLetterRegion(string region)
+            => ThreeToTwoLetterRegion(region.AsSpan());
+#endif
+
+        public static string ThreeToTwoLetterRegion(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> region
+#else
+            string region
+#endif
+            )
         {
             /* convert 3 character code to 2 character code if possible *CWB*/
             int offset = FindIndex(_countries3, region);
@@ -128,11 +199,21 @@
         /// Linear search of the string array. The arrays are unfortunately ordered by the
         /// two-letter target code, not the three-letter search code, which seems backwards.
         /// </summary>
-        private static int FindIndex(string[] array, string target)
+        private static int FindIndex(string[] array,
+#if FEATURE_SPAN
+            ReadOnlySpan<char> target
+#else
+            string target
+#endif
+            )
         {
             for (int i = 0; i < array.Length; i++)
             {
+#if FEATURE_SPAN
+                if (target.Equals(array[i], StringComparison.Ordinal))
+#else
                 if (target.Equals(array[i]))
+#endif
                 {
                     return i;
                 }
@@ -459,25 +540,48 @@
             "ANT", "BUR", "SCG", "FXX", "ROM", "SUN", "TMP", "YMD", "YUG", "ZAR",
         };
 
-
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string GetCurrentCountryID(string oldID)
+            => GetCurrentCountryID(oldID.AsSpan());
+#endif
+
+        public static string GetCurrentCountryID(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> oldID
+#else
+            string oldID
+#endif
+            )
         {
             int offset = FindIndex(_deprecatedCountries, oldID);
             if (offset >= 0)
             {
                 return _replacementCountries[offset];
             }
-            return oldID;
+            return oldID.ToString();
         }
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string GetCurrentLanguageID(string oldID)
+            => GetCurrentLanguageID(oldID.AsSpan());
+#endif
+
+        public static string GetCurrentLanguageID(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> oldID
+#else
+            string oldID
+#endif
+            )
         {
             int offset = FindIndex(_obsoleteLanguages, oldID);
             if (offset >= 0)
             {
                 return _replacementLanguages[offset];
             }
-            return oldID;
+            return oldID.ToString();
         }
     }
 }

--- a/src/ICU4N/Support/Globalization/UCultureData.cs
+++ b/src/ICU4N/Support/Globalization/UCultureData.cs
@@ -121,11 +121,11 @@ namespace ICU4N.Globalization
 
         // Do NOT call this in the constructor of UCultureInfo
         public PluralRules OrdinalPluralRules
-            => LazyInitializer.EnsureInitialized(ref ordinalPluralRules, () => PluralRules.GetInstance(name, PluralType.Ordinal));
+            => LazyInitializer.EnsureInitialized(ref ordinalPluralRules, () => PluralRules.GetInstance(name, PluralType.Ordinal))!;
 
         // Do NOT call this in the constructor of UCultureInfo
         public PluralRules CardinalPluralRules
-            => LazyInitializer.EnsureInitialized(ref cardinalPluralRules, () => PluralRules.GetInstance(name, PluralType.Cardinal));
+            => LazyInitializer.EnsureInitialized(ref cardinalPluralRules, () => PluralRules.GetInstance(name, PluralType.Cardinal))!;
 
 
         internal object? nonNullIfNFIInitialized; // Marker to tell us we are "done" loading NFI data if not null.
@@ -199,7 +199,7 @@ namespace ICU4N.Globalization
 
             // ICU4N: We cannot use the invariant culture if there are keywords to parse,
             // so we must use localeID here.
-            if (string.IsNullOrEmpty(cultureInfo.FullName))
+            if (string.IsNullOrEmpty(cultureInfo!.FullName))
             {
                 return Invariant;
             }
@@ -257,7 +257,7 @@ namespace ICU4N.Globalization
         internal UCultureData(UCultureInfo cultureInfo, bool skipKeywords = false)
         {
             Debug.Assert(cultureInfo != null);
-            this.localeID = cultureInfo.localeID;
+            this.localeID = cultureInfo!.localeID;
             this.isInvariantCulture = cultureInfo.isInvariantCulture;
             this.isNeutralCulture = cultureInfo.isNeutralCulture;
             this.name = cultureInfo.Name; // base name from ICU
@@ -274,6 +274,8 @@ namespace ICU4N.Globalization
 
         private UCultureData()
         {
+            localeID = string.Empty;
+            name = string.Empty;
         }
 
         internal void GetNFIValues(UNumberFormatInfo nfi)
@@ -459,7 +461,7 @@ namespace ICU4N.Globalization
             public NumberElementSymbolLoader(UCultureData cultureData)
             {
                 Debug.Assert(cultureData is not null);
-                this.cultureData = cultureData;
+                this.cultureData = cultureData!;
             }
 
             public bool IsFullyPopulated => cultureData.decimalSeparator is not null &&
@@ -549,7 +551,7 @@ namespace ICU4N.Globalization
             public NumberElementPatternLoader(UCultureData cultureData)
             {
                 Debug.Assert(cultureData is not null);
-                this.cultureData = cultureData;
+                this.cultureData = cultureData!;
             }
 
             public bool IsFullyPopulated => cultureData.decimalFormat is not null &&
@@ -622,13 +624,13 @@ namespace ICU4N.Globalization
 
         internal sealed class CultureDataSink : ResourceSink
         {
-            private IResourceTableLoader loader;
+            private IResourceTableLoader? loader;
 
             [MemberNotNull(nameof(loader))]
             public void SetLoader(IResourceTableLoader loader)
             {
                 Debug.Assert(loader is not null);
-                this.loader = loader;
+                this.loader = loader!;
             }
 
             public override void Put(ResourceKey key, ResourceValue value, bool noFallback)
@@ -637,7 +639,7 @@ namespace ICU4N.Globalization
                 IResourceTable symbolsTable = value.GetTable();
                 for (int j = 0; symbolsTable.GetKeyAndValue(j, key, value); ++j)
                 {
-                    loader.Put(j, symbolsTable, key, value, noFallback);
+                    loader!.Put(j, symbolsTable, key, value, noFallback);
                 }
             }
         }

--- a/src/ICU4N/Support/Text/StringExtensions.cs
+++ b/src/ICU4N/Support/Text/StringExtensions.cs
@@ -14,9 +14,29 @@ namespace ICU4N.Support.Text
         /// <summary>Copies the contents of this string into the destination span.</summary>
         /// <param name="s">This string.</param>
         /// <param name="destination">The span into which to copy this string's contents.</param>
+        /// <exception cref="ArgumentException">If <paramref name="destination"/> is too short.</exception>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static void CopyTo(this string s, Span<char> destination) // ICU4N TODO: Move to J2N?
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            if ((uint)s.Length <= (uint)destination.Length)
+            {
+                s.AsSpan().CopyTo(destination);
+            }
+            else
+            {
+                throw new ArgumentException("Destination is too short.", nameof(destination)); // Argument_DestinationTooShort
+            }
+        }
+
+        /// <summary>Copies the contents of this string into the destination span.</summary>
+        /// <param name="s">This string.</param>
+        /// <param name="destination">The span into which to copy this string's contents.</param>
         /// <returns>true if the data was copied; false if the destination was too short to fit the contents of the string.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCopyTo(this string s, Span<char> destination)
+        public static bool TryCopyTo(this string s, Span<char> destination) // ICU4N TODO: Move to J2N?
         {
             if (s is null)
                 throw new ArgumentNullException(nameof(s));

--- a/src/ICU4N/Text/RuleBasedNumberFormat.cs
+++ b/src/ICU4N/Text/RuleBasedNumberFormat.cs
@@ -1929,11 +1929,19 @@ namespace ICU4N.Text
                 publicRuleSetNames = (string[])localizations[0].Clone();
 
                 IDictionary<string, string[]> m = new Dictionary<string, string[]>();
+#if FEATURE_SPAN
+                using var parser = new LocaleIDParser(stackalloc char[32], ReadOnlySpan<char>.Empty);
+#else
+                using var parser = new LocaleIDParser(string.Empty);
+#endif
+
                 for (int i = 1; i < localizations.Length; ++i)
                 {
                     string[] data = localizations[i];
                     // ICU4N: Convert any culture names to use underscore instead of dash
-                    string loc = new LocaleIDParser(data[0]).GetBaseName();
+                    parser.Reset(data[0]);
+
+                    string loc = parser.GetBaseName();
                     string[] names = new string[data.Length - 1];
                     if (names.Length != publicRuleSetNames.Length)
                     {

--- a/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
+++ b/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net7.0</TargetFramework>
-  
+
+    <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   
@@ -13,6 +15,7 @@
     <Compile Include="..\..\ICU4N\Impl\Locale\AsciiUtil.cs" Link="Shared\AsciiUtil.cs" />
     <Compile Include="..\..\ICU4N\Support\Collections\DictionaryExtensions.cs" Link="Shared\DictionaryExtensions.cs" />
     <Compile Include="..\..\ICU4N\Support\Globalization\LocaleID.cs" Link="Shared\LocaleID.cs" />
+    <Compile Include="..\..\ICU4N\Support\Text\ValueStringBuilder.cs" Link="Shared\ValueStringBuilder.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/tools/ICU4JResourceConverter/ResourceUtil.cs
+++ b/src/tools/ICU4JResourceConverter/ResourceUtil.cs
@@ -152,7 +152,14 @@ namespace JavaResourceConverter
 
         public static string GetDotNetLocaleName(string baseName)
         {
-            return baseName == "root" ? "" : new LocaleIDParser(baseName).GetName();
+            if (baseName == "root") return string.Empty;
+
+#if FEATURE_SPAN
+            using var parser = new LocaleIDParser(stackalloc char[32], baseName);
+#else
+            using var parser = new LocaleIDParser(baseName);
+#endif
+            return parser.GetName();
         }
 
         /// <summary>

--- a/tests/ICU4N.Tests/Dev/Test/Format/NumberFormatDataDrivenTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Format/NumberFormatDataDrivenTest.cs
@@ -396,7 +396,11 @@ namespace ICU4N.Dev.Test.Format
             private java.util.Locale toLocale(UCultureInfo uCultureInfo) // ICU4N: Convert UCultureInfo to java.util.Locale
             {
                 string localeId = uCultureInfo.ToString();
-                var parser = new LocaleIDParser(localeId);
+#if FEATURE_SPAN
+                using var parser = new LocaleIDParser(stackalloc char[32], localeId);
+#else
+                using var parser = new LocaleIDParser(localeID);
+#endif
 
                 string language = parser.GetLanguage();
                 string country = parser.GetCountry();

--- a/tests/ICU4N.Tests/Support/Resources/SatelliteAssemblyTest.cs
+++ b/tests/ICU4N.Tests/Support/Resources/SatelliteAssemblyTest.cs
@@ -36,7 +36,14 @@ namespace ICU4N.Support.Resources
         // ICU4N TODO: Move special case converter to common location
         public static string GetDotNetLocaleName(string baseName)
         {
-            return baseName == "root" ? "" : new LocaleIDParser(baseName).GetName();
+            if (baseName == "root") return string.Empty;
+
+#if FEATURE_SPAN
+            using var parser = new LocaleIDParser(stackalloc char[32], baseName);
+#else
+            using var parser = new LocaleIDParser(baseName);
+#endif
+            return parser.GetName();
         }
 
         public static void LoadManifest(Assembly assembly, string manifestName, IList<string> result)


### PR DESCRIPTION
The `LocaleIDParser` is used by `UCultureInfo` and in `UResourceBundle` as one of the primary ways of determining which resources to load, so optimizing this parser is very impactful in reducing heap allocations and GC.