### PR TITLE
PERFORMANCE: ICU4N.Impl.RuleCharacterIterator: Fixed bottleneck when calling Lookahead() method

### DIFF
--- a/src/ICU4N.Transliterator/Text/TransliteratorParser.cs
+++ b/src/ICU4N.Transliterator/Text/TransliteratorParser.cs
@@ -532,9 +532,7 @@ namespace ICU4N.Text
                         {
                             SyntaxError("Trailing backslash", rule, start);
                         }
-                        iref[0] = pos;
-                        int escaped = Utility.UnescapeAt(rule, iref);
-                        pos = iref[0];
+                        int escaped = Utility.UnescapeAt(rule, ref pos); // ICU4N: Changed array to ref parameter
                         if (escaped == -1)
                         {
                             SyntaxError("Malformed escape", rule, start);

--- a/src/ICU4N/Impl/RuleCharacterIterator.cs
+++ b/src/ICU4N/Impl/RuleCharacterIterator.cs
@@ -168,7 +168,23 @@ namespace ICU4N.Impl
                 if (c == '\\' && (options & RuleCharacterIteratorOptions.ParseEscapes) != 0)
                 {
                     int offset = 0;
+#if FEATURE_SPAN
                     c = Utility.UnescapeAt(Lookahead(), ref offset); // ICU4N: Changed array to ref parameter
+#else
+                    // ICU4N: Refactored so we don't call Lookahead and allocate a string just for this operation
+                    int originalOffset;
+                    if (buf != null)
+                    {
+                        originalOffset = offset = buf.Length - bufPos;
+                        c = Utility.UnescapeAt(buf, ref offset); // ICU4N: Changed array to ref parameter
+                    }
+                    else
+                    {
+                        originalOffset = offset = pos.Index;
+                        c = Utility.UnescapeAt(text, ref offset); // ICU4N: Changed array to ref parameter
+                    }
+                    offset -= originalOffset;
+#endif
                     Jumpahead(offset);
                     isEscaped = true;
                     if (c < 0)

--- a/src/ICU4N/Impl/RuleCharacterIterator.cs
+++ b/src/ICU4N/Impl/RuleCharacterIterator.cs
@@ -167,9 +167,9 @@ namespace ICU4N.Impl
 
                 if (c == '\\' && (options & RuleCharacterIteratorOptions.ParseEscapes) != 0)
                 {
-                    int[] offset = new int[] { 0 };
-                    c = Utility.UnescapeAt(Lookahead(), offset);
-                    Jumpahead(offset[0]);
+                    int offset = 0;
+                    c = Utility.UnescapeAt(Lookahead(), ref offset); // ICU4N: Changed array to ref parameter
+                    Jumpahead(offset);
                     isEscaped = true;
                     if (c < 0)
                     {
@@ -283,6 +283,20 @@ namespace ICU4N.Impl
         /// </remarks>
         /// <returns>A string containing the characters to be returned by future
         /// calls to <see cref="Next(RuleCharacterIteratorOptions)"/>.</returns>
+
+#if FEATURE_SPAN
+        public virtual ReadOnlySpan<char> Lookahead()
+        {
+            if (buf != null)
+            {
+                return buf.AsSpan(bufPos, buf.Length - bufPos);
+            }
+            else
+            {
+                return text.AsSpan(pos.Index);
+            }
+        }
+#else
         public virtual string Lookahead()
         {
             if (buf != null)
@@ -294,6 +308,7 @@ namespace ICU4N.Impl
                 return text.Substring(pos.Index);
             }
         }
+#endif
 
         /// <summary>
         /// Advances the position by the given number of 16-bit code units.

--- a/src/ICU4N/Impl/Utility.cs
+++ b/src/ICU4N/Impl/Utility.cs
@@ -915,6 +915,156 @@ namespace ICU4N.Impl
             return c;
         }
 
+#if !FEATURE_SPAN
+        /// <summary>
+        /// Convert an escape to a 32-bit code point value.  We attempt
+        /// to parallel the icu4c unescapeAt() function.
+        /// </summary>
+        /// <param name="s">The character sequence to escape.</param>
+        /// <param name="offset16">An offset to the character
+        /// <em>after</em> the backslash.  Upon return offset16 will
+        /// be updated to point after the escape sequence.</param>
+        /// <returns>Character value from 0 to 10FFFF, or -1 on error.</returns>
+        public static int UnescapeAt(char[] s, ref int offset16) // ICU4N: Changed array to ref parameter
+        {
+            int c;
+            int result = 0;
+            int n = 0;
+            int minDig = 0;
+            int maxDig = 0;
+            int bitsPerDigit = 4;
+            int dig;
+            int i;
+            bool braces = false;
+
+            /* Check that offset is in range */
+            int offset = offset16;
+            int length = s.Length;
+            if (offset < 0 || offset >= length)
+            {
+                return -1;
+            }
+
+            /* Fetch first UChar after '\\' */
+            c = Character.CodePointAt(s, offset);
+            offset += UTF16.GetCharCount(c);
+
+            /* Convert hexadecimal and octal escapes */
+            switch (c)
+            {
+                case 'u':
+                    minDig = maxDig = 4;
+                    break;
+                case 'U':
+                    minDig = maxDig = 8;
+                    break;
+                case 'x':
+                    minDig = 1;
+                    if (offset < length && UTF16.CharAt(s, offset) == 0x7B /*{*/)
+                    {
+                        ++offset;
+                        braces = true;
+                        maxDig = 8;
+                    }
+                    else
+                    {
+                        maxDig = 2;
+                    }
+                    break;
+                default:
+                    dig = UChar.Digit(c, 8);
+                    if (dig >= 0)
+                    {
+                        minDig = 1;
+                        maxDig = 3;
+                        n = 1; /* Already have first octal digit */
+                        bitsPerDigit = 3;
+                        result = dig;
+                    }
+                    break;
+            }
+            if (minDig != 0)
+            {
+                while (offset < length && n < maxDig)
+                {
+                    c = UTF16.CharAt(s, offset);
+                    dig = UChar.Digit(c, (bitsPerDigit == 3) ? 8 : 16);
+                    if (dig < 0)
+                    {
+                        break;
+                    }
+                    result = (result << bitsPerDigit) | dig;
+                    offset += UTF16.GetCharCount(c);
+                    ++n;
+                }
+                if (n < minDig)
+                {
+                    return -1;
+                }
+                if (braces)
+                {
+                    if (c != 0x7D /*}*/)
+                    {
+                        return -1;
+                    }
+                    ++offset;
+                }
+                if (result < 0 || result >= 0x110000)
+                {
+                    return -1;
+                }
+                // If an escape sequence specifies a lead surrogate, see
+                // if there is a trail surrogate after it, either as an
+                // escape or as a literal.  If so, join them up into a
+                // supplementary.
+                if (offset < length &&
+                        UTF16.IsLeadSurrogate((char)result))
+                {
+                    int ahead = offset + 1;
+                    c = s[offset]; // [sic] get 16-bit code unit
+                    if (c == '\\' && ahead < length)
+                    {
+                        c = UnescapeAt(s, ref ahead); // ICU4N: Changed array to ref parameter
+                    }
+                    if (UTF16.IsTrailSurrogate((char)c))
+                    {
+                        offset = ahead;
+                        result = Character.ToCodePoint((char)result, (char)c);
+                    }
+                }
+                offset16 = offset;
+                return result;
+            }
+
+            /* Convert C-style escapes in table */
+            for (i = 0; i < UNESCAPE_MAP.Length; i += 2)
+            {
+                if (c == UNESCAPE_MAP[i])
+                {
+                    offset16 = offset;
+                    return UNESCAPE_MAP[i + 1];
+                }
+                else if (c < UNESCAPE_MAP[i])
+                {
+                    break;
+                }
+            }
+
+            /* Map \cX to control-X: X & 0x1F */
+            if (c == 'c' && offset < length)
+            {
+                c = UTF16.CharAt(s, offset);
+                offset16 = offset + UTF16.GetCharCount(c);
+                return 0x1F & c;
+            }
+
+            /* If no special forms are recognized, then consider
+             * the backslash to generically escape the next character. */
+            offset16 = offset;
+            return c;
+        }
+
+#endif
 
 
 #if FEATURE_SPAN

--- a/src/ICU4N/Impl/Utility.cs
+++ b/src/ICU4N/Impl/Utility.cs
@@ -1,8 +1,12 @@
-﻿using ICU4N.Text;
+﻿using ICU4N.Support.Text;
+using ICU4N.Text;
 using J2N;
 using J2N.Collections;
 using J2N.Text;
 using System;
+#if FEATURE_SPAN
+using System.Buffers;
+#endif
 using System.Collections.Generic;
 using System.Globalization;
 using System.Runtime.CompilerServices;
@@ -18,6 +22,8 @@ namespace ICU4N.Impl
         private const char APOSTROPHE = '\'';
         private const char BACKSLASH = '\\';
         private const int MAGIC_UNSIGNED = unchecked((int)0x80000000);
+
+        private const int CharStackBufferSize = 32;
 
         // ICU4N: No need for ArrayEquals overloads because in .NET we have
         // strongly typed generics that aren't just syntactic sugar for object.
@@ -693,7 +699,11 @@ namespace ICU4N.Impl
         /// </summary>
         public static string Escape(string s)
         {
+#if FEATURE_SPAN
+            ValueStringBuilder buf = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
+#else
             StringBuilder buf = new StringBuilder();
+#endif
             for (int i = 0; i < s.Length;)
             {
                 int c = Character.CodePointAt(s, i);
@@ -735,16 +745,38 @@ namespace ICU4N.Impl
             /*v*/ (char)0x76, (char)0x0b
         };
 
+#if FEATURE_SPAN && !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
         /// <summary>
         /// Convert an escape to a 32-bit code point value.  We attempt
         /// to parallel the icu4c unescapeAt() function.
         /// </summary>
-        /// <param name="s"></param>
-        /// <param name="offset16">An array containing offset to the character
-        /// <em>after</em> the backslash.  Upon return offset16[0] will
+        /// <param name="s">The character sequence to escape.</param>
+        /// <param name="offset16">An offset to the character
+        /// <em>after</em> the backslash.  Upon return offset16 will
         /// be updated to point after the escape sequence.</param>
         /// <returns>Character value from 0 to 10FFFF, or -1 on error.</returns>
-        public static int UnescapeAt(string s, int[] offset16)
+        // ICU4N: To fix lack of implicit conversion
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int UnescapeAt(string s, ref int offset16)
+            => UnescapeAt(s.AsSpan(), ref offset16);
+#endif
+
+        /// <summary>
+        /// Convert an escape to a 32-bit code point value.  We attempt
+        /// to parallel the icu4c unescapeAt() function.
+        /// </summary>
+        /// <param name="s">The character sequence to escape.</param>
+        /// <param name="offset16">An offset to the character
+        /// <em>after</em> the backslash.  Upon return offset16 will
+        /// be updated to point after the escape sequence.</param>
+        /// <returns>Character value from 0 to 10FFFF, or -1 on error.</returns>
+        public static int UnescapeAt(
+#if FEATURE_SPAN
+            ReadOnlySpan<char> s,
+#else
+            string s,
+#endif
+            ref int offset16) // ICU4N: Changed array to ref parameter
         {
             int c;
             int result = 0;
@@ -757,7 +789,7 @@ namespace ICU4N.Impl
             bool braces = false;
 
             /* Check that offset is in range */
-            int offset = offset16[0];
+            int offset = offset16;
             int length = s.Length;
             if (offset < 0 || offset >= length)
             {
@@ -843,9 +875,7 @@ namespace ICU4N.Impl
                     c = s[offset]; // [sic] get 16-bit code unit
                     if (c == '\\' && ahead < length)
                     {
-                        int[] o = new int[] { ahead };
-                        c = UnescapeAt(s, o);
-                        ahead = o[0];
+                        c = UnescapeAt(s, ref ahead); // ICU4N: Changed array to ref parameter
                     }
                     if (UTF16.IsTrailSurrogate((char)c))
                     {
@@ -853,7 +883,7 @@ namespace ICU4N.Impl
                         result = Character.ToCodePoint((char)result, (char)c);
                     }
                 }
-                offset16[0] = offset;
+                offset16 = offset;
                 return result;
             }
 
@@ -862,7 +892,7 @@ namespace ICU4N.Impl
             {
                 if (c == UNESCAPE_MAP[i])
                 {
-                    offset16[0] = offset;
+                    offset16 = offset;
                     return UNESCAPE_MAP[i + 1];
                 }
                 else if (c < UNESCAPE_MAP[i])
@@ -875,38 +905,66 @@ namespace ICU4N.Impl
             if (c == 'c' && offset < length)
             {
                 c = UTF16.CharAt(s, offset);
-                offset16[0] = offset + UTF16.GetCharCount(c);
+                offset16 = offset + UTF16.GetCharCount(c);
                 return 0x1F & c;
             }
 
             /* If no special forms are recognized, then consider
              * the backslash to generically escape the next character. */
-            offset16[0] = offset;
+            offset16 = offset;
             return c;
         }
 
+
+
+#if FEATURE_SPAN
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
         /// <summary>
-        /// Convert all escapes in a given string using <see cref="UnescapeAt(string, int[])"/>.
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If an invalid escape is seen.</exception>
+        // ICU4N: To fix lack of implicit conversion
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string Unescape(string s)
+            => Unescape(s.AsSpan());
+#endif
+
+        /// <summary>
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If an invalid escape is seen.</exception>
+        public static string Unescape(ReadOnlySpan<char> s)
+        {
+            ValueStringBuilder buf = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
+#else
+        /// <summary>
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(string, ref int)"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If an invalid escape is seen.</exception>
         public static string Unescape(string s)
         {
             StringBuilder buf = new StringBuilder();
-            int[] pos = new int[1];
+#endif
+            int pos;
             for (int i = 0; i < s.Length;)
             {
                 char c = s[i++];
                 if (c == '\\')
                 {
-                    pos[0] = i;
-                    int e = UnescapeAt(s, pos);
+                    pos = i;
+                    int e = UnescapeAt(s, ref pos); // ICU4N: Changed array to ref parameter
                     if (e < 0)
                     {
-                        throw new ArgumentException("Invalid escape sequence " +
-                                s.Substring(i - 1, Math.Min(i + 8, s.Length) - (i - 1))); // ICU4N: Corrected 2nd parameter
+                        throw new ArgumentException(
+#if FEATURE_SPAN
+                            StringHelper.Concat("Invalid escape sequence ".AsSpan(), s.Slice(i - 1, Math.Min(i + 8, s.Length) - (i - 1)))); // ICU4N: Corrected 2nd parameter
+#else
+                            string.Concat("Invalid escape sequence ", s.Substring(i - 1, Math.Min(i + 8, s.Length) - (i - 1)))); // ICU4N: Corrected 2nd parameter
+#endif
+
                     }
                     buf.AppendCodePoint(e);
-                    i = pos[0];
+                    i = pos;
                 }
                 else
                 {
@@ -916,21 +974,41 @@ namespace ICU4N.Impl
             return buf.ToString();
         }
 
+#if FEATURE_SPAN
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
         /// <summary>
-        /// Convert all escapes in a given string using <see cref="UnescapeAt(string, int[])"/>.
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
+        /// Leave invalid escape sequences unchanged.
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string UnescapeLeniently(string s)
+            => UnescapeLeniently(s.AsSpan());
+#endif
+        /// <summary>
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
+        /// Leave invalid escape sequences unchanged.
+        /// </summary>
+        public static string UnescapeLeniently(ReadOnlySpan<char> s)
+        {
+            ValueStringBuilder buf = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
+#else
+        /// <summary>
+        /// Convert all escapes in a given string using <see cref="UnescapeAt(string, ref int)"/>.
         /// Leave invalid escape sequences unchanged.
         /// </summary>
         public static string UnescapeLeniently(string s)
         {
             StringBuilder buf = new StringBuilder();
-            int[] pos = new int[1];
+#endif
+            int pos;
             for (int i = 0; i < s.Length;)
             {
                 char c = s[i++];
                 if (c == '\\')
                 {
-                    pos[0] = i;
-                    int e = UnescapeAt(s, pos);
+                    //pos[0] = i;
+                    pos = i;
+                    int e = UnescapeAt(s, ref pos); // ICU4N: Changed array to ref parameter
                     if (e < 0)
                     {
                         buf.Append(c);
@@ -938,7 +1016,7 @@ namespace ICU4N.Impl
                     else
                     {
                         buf.AppendCodePoint(e);
-                        i = pos[0];
+                        i = pos;
                     }
                 }
                 else
@@ -958,6 +1036,8 @@ namespace ICU4N.Impl
             return Hex(ch, 4);
         }
 
+#nullable enable
+
         /// <summary>
         /// Supplies a zero-padded hex representation of an integer (without 0x)
         /// </summary>
@@ -970,6 +1050,32 @@ namespace ICU4N.Impl
                 i = -i;
             }
             //string result = Long.toString(i, 16).toUpperCase(Locale.ENGLISH);
+#if FEATURE_SPAN
+            int length = places + (negative ? 1 : 0);
+            bool usePool = length > CharStackBufferSize;
+            char[]? arrayToReturnToPool = usePool ? ArrayPool<char>.Shared.Rent(length) : null;
+            try
+            {
+                Span<char> buffer = usePool ? arrayToReturnToPool : stackalloc char[length];
+
+                bool success = J2N.Numerics.Int64.TryFormat(i, buffer, out int charsWritten, format: "X".AsSpan(), CultureInfo.InvariantCulture);
+                // Move the chars to the end of the buffer
+                int startIndex = buffer.Length - charsWritten;
+                buffer.Slice(0, charsWritten).CopyTo(buffer.Slice(startIndex, charsWritten));
+                for (int j = 0; j < startIndex; j++)
+                {
+                    buffer[j] = '0';
+                }
+                if (negative) buffer[0] = '-';
+                return buffer.ToString();
+            }
+            finally
+            {
+                if (arrayToReturnToPool is not null)
+                    ArrayPool<char>.Shared.Return(arrayToReturnToPool);
+            }
+            
+#else
             string result = i.ToString("X", CultureInfo.InvariantCulture);
             if (result.Length < places)
             {
@@ -980,7 +1086,10 @@ namespace ICU4N.Impl
                 return '-' + result;
             }
             return result;
+#endif
         }
+
+#nullable restore
 
         // ICU4N specific - Hex(ICharSequence s) moved to UtilityExtension.tt
 

--- a/src/ICU4N/Text/RBBIRuleScanner.cs
+++ b/src/ICU4N/Text/RBBIRuleScanner.cs
@@ -889,16 +889,15 @@ namespace ICU4N.Text
                 if (c.fChar == '\\')
                 {
                     c.fEscaped = true;
-                    int[] unescapeIndex = new int[1];
-                    unescapeIndex[0] = fNextIndex;
-                    c.fChar = Utility.UnescapeAt(fRB.fRules, unescapeIndex);
-                    if (unescapeIndex[0] == fNextIndex)
+                    int unescapeIndex = fNextIndex;
+                    c.fChar = Utility.UnescapeAt(fRB.fRules, ref unescapeIndex); // ICU4N: Changed array to ref parameter
+                    if (unescapeIndex == fNextIndex)
                     {
                         Error(RBBIRuleBuilder.U_BRK_HEX_DIGITS_EXPECTED);
                     }
 
-                    fCharNum += unescapeIndex[0] - fNextIndex;
-                    fNextIndex = unescapeIndex[0];
+                    fCharNum += unescapeIndex - fNextIndex;
+                    fNextIndex = unescapeIndex;
                 }
             }
             // putc(c.fChar, stdout);

--- a/src/ICU4N/Text/UnicodeSet.cs
+++ b/src/ICU4N/Text/UnicodeSet.cs
@@ -4004,7 +4004,7 @@ namespace ICU4N.Text
         private void ApplyPropertyPattern(RuleCharacterIterator chars,
             IAppendable rebuiltPat, ISymbolTable symbols)
         {
-            string patStr = chars.Lookahead();
+            string patStr = chars.Lookahead().ToString();
             ParsePosition pos = new ParsePosition(0);
             ApplyPropertyPattern(patStr, pos, symbols);
             if (pos.Index == 0)

--- a/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBITestExtended.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBITestExtended.cs
@@ -383,14 +383,13 @@ namespace ICU4N.Dev.Test.Rbbi
                             }
 
                             // Let unescape handle the back slash.
-                            int[] charIdxAr = new int[1];
-                            charIdxAr[0] = charIdx;
-                            cp = Utility.UnescapeAt(testString, charIdxAr);
+                            int charIdxAr = charIdx;
+                            cp = Utility.UnescapeAt(testString, ref charIdxAr); // ICU4N: Changed array to ref parameter
                             if (cp != -1)
                             {
                                 // Escape sequence was recognized.  Insert the char
                                 //   into the test data.
-                                charIdx = charIdxAr[0];
+                                charIdx = charIdxAr;
                                 tp.dataToBreak.AppendCodePoint(cp);
                                 for (i = tp.dataToBreak.Length - 1; i >= 0 && tp.srcLine[i] == 0; i--)
                                 {


### PR DESCRIPTION
The `Substring()` method in .NET performs horribly compared to Java. So, the `Lookahead()` method was modified to return `ReadOnlySpan<char>` so it can be sliced without allocating substrings.

On .NET Framework 4.0, we work around this by passing in the buffer instead of calling `Lookahead()`.