### PR TITLE
Removed .NET Standard 1.x and .NET Core 1.x build features (Fixes #72)

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -94,6 +94,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_REGEX_MATCHTIMEOUT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TASK_ASYNC_AWAIT</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TASK_RUN</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_TYPE_GETCUSTOMATTRIBUTE_GENERIC</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_TYPEDWEAKREFERENCE</DefineConstants>
     
   </PropertyGroup>
@@ -128,24 +129,6 @@
     <!-- NOTE: Microsoft's recommendation is not to use the ICloneable interface.
         To add it to the build, just add /p:IncludeICloneable to the command line. -->
     <DefineConstants Condition=" '$(IncludeICloneable)' == 'true' ">$(DefineConstants);FEATURE_CLONEABLE</DefineConstants>
-  </PropertyGroup>
-
-  <!-- Features in .NET Standard 1.x and .NET Core 1.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard1.')) Or $(TargetFramework.StartsWith('netcoreapp1.')) ">
-
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_X</DefineConstants>
-    <DefineConstants>$(DefineConstants);NETCOREAPP1_X</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_UNKNOWNLANGUAGE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TYPEEXTENSIONS_GETTYPEINFO</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_EXCEPTION_HRESULT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_MICROSOFT_EXTENSIONS_CACHING</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_IREADONLYCOLLECTIONS</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_REGEX_MATCHTIMEOUT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TASK_ASYNC_AWAIT</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TASK_RUN</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_TYPEDWEAKREFERENCE</DefineConstants>
-
   </PropertyGroup>
 
   <!-- Features in .NET Framework 4.6+ only -->

--- a/src/ICU4N.Collation/Text/RuleBasedCollator.cs
+++ b/src/ICU4N.Collation/Text/RuleBasedCollator.cs
@@ -160,12 +160,7 @@ namespace ICU4N.Text
             //            // Most code using Collator does not need to build a Collator from rules.
             //            // By using reflection, most code will not have a static dependency on the builder code.
             //            // CollationBuilder builder = new CollationBuilder(base);
-            //            Assembly classLoader =
-            //#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            //                GetType().GetTypeInfo().Assembly; // ClassLoaderUtil.getClassLoader(GetUnicodeCategory());
-            //#else
-            //                GetType().Assembly; // ClassLoaderUtil.getClassLoader(GetUnicodeCategory());
-            //#endif
+            //            Assembly classLoader = GetType().Assembly; // ClassLoaderUtil.getClassLoader(GetUnicodeCategory());
             //            CollationTailoring t;
             //            try
             //            {

--- a/src/ICU4N.TestFramework/Dev/Test/TestUtil.cs
+++ b/src/ICU4N.TestFramework/Dev/Test/TestUtil.cs
@@ -23,11 +23,7 @@ namespace ICU4N.Dev.Test
             Stream input = null;
             try
             {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                Assembly assembly = typeof(TestUtil).GetTypeInfo().Assembly;
-#else
                 Assembly assembly = typeof(TestUtil).Assembly;
-#endif
                 input = assembly.GetManifestResourceStream(DATA_PATH + name);
             }
             catch (Exception t)

--- a/src/ICU4N/Impl/ICUBinary.cs
+++ b/src/ICU4N/Impl/ICUBinary.cs
@@ -346,11 +346,7 @@ namespace ICU4N.Impl
         {
             // ICU4N TODO: Fix path
             // Normally com.ibm.icu.impl.ICUBinary.dataPath.
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            string dataPath = ICUConfig.Get(typeof(ICUBinary).GetTypeInfo().Name + "_DataPath");
-#else
             string dataPath = ICUConfig.Get(typeof(ICUBinary).Name + "_DataPath");
-#endif
             if (dataPath != null)
             {
                 AddDataFilesFromPath(dataPath, icuDataFiles);
@@ -588,11 +584,7 @@ namespace ICU4N.Impl
             }
             if (assembly == null)
             {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                assembly = typeof(ICUData).GetTypeInfo().Assembly;
-#else
                 assembly = typeof(ICUData).Assembly;
-#endif
             }
             if (resourceName == null)
             {

--- a/src/ICU4N/Impl/ICUData.cs
+++ b/src/ICU4N/Impl/ICUData.cs
@@ -113,11 +113,7 @@ namespace ICU4N.Impl
 
         private static Stream GetStream(Type root, string resourceName, bool required)
         {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly assembly = root.GetTypeInfo().Assembly;
-#else
             Assembly assembly = root.Assembly;
-#endif
             return GetStream(assembly, resourceName, required);
         }
 

--- a/src/ICU4N/Impl/ICUResourceBundle.cs
+++ b/src/ICU4N/Impl/ICUResourceBundle.cs
@@ -38,11 +38,7 @@ namespace ICU4N.Impl
         /// The class loader constant to be used with <see cref="GetBundleInstance(string, string, Assembly, OpenType)"/> API
         /// </summary>
         public static readonly Assembly IcuDataAssembly =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            typeof(ICUData).GetTypeInfo().Assembly; //ClassLoaderUtil.getClassLoader(ICUData.class); // ICU4N specific: This was named ICU_DATA_CLASS_LOADER in Java
-#else
             typeof(ICUData).Assembly; //ClassLoaderUtil.getClassLoader(ICUData.class); // ICU4N specific: This was named ICU_DATA_CLASS_LOADER in Java
-#endif
 
         /// <summary>
         /// The name of the resource containing the installed locales

--- a/src/ICU4N/Impl/LocaleUtility.cs
+++ b/src/ICU4N/Impl/LocaleUtility.cs
@@ -39,18 +39,7 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
 
             try
             {
-                CultureInfo culture = new CultureInfo(newName);
-
-#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-                // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-                // to be created, but will be "unknown" languages. We need to manually
-                // ignore these.
-                if (culture.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-                {
-                    return null;
-                }
-#endif
-                return culture;
+                return new CultureInfo(newName);
             }
             catch (CultureNotFoundException)
             {
@@ -175,15 +164,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         //                return null;
         //            }
 
-        //#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-        //            // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-        //            // to be created, but will be "unknown" languages. We need to manually
-        //            // ignore these.
-        //            if (loc.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-        //            {
-        //                return CultureInfo.InvariantCulture;
-        //            }
-        //#endif
         //            // ICU4N: We use the original ICU fallback scheme rather than
         //            // simply using loc.Parent.
 
@@ -216,15 +196,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             if (CultureInfo.InvariantCulture.Equals(loc))
                 return null;
 
-#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-            // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-            // to be created, but will be "unknown" languages. We need to manually
-            // ignore these.
-            if (loc.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-            {
-                return null;
-            }
-#endif
             // ICU4N: We use the original ICU fallback scheme rather than
             // simply using loc.Parent.
             string? fallbackLocaleID = FallbackAsString(loc.Name, separator: '-');
@@ -246,16 +217,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         {
             if (UCultureInfo.InvariantCulture.Equals(loc))
                 return null;
-
-#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-            // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-            // to be created, but will be "unknown" languages. We need to manually
-            // ignore these.
-            if (loc.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-            {
-                return null;
-            }
-#endif
 
             string? fallbackLocaleID = FallbackAsString(loc.Name);
             return string.IsNullOrEmpty(fallbackLocaleID) ? null : new UCultureInfo(fallbackLocaleID!);
@@ -340,16 +301,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                 {
                     string newName = string.Join("-", segments.Take(i));
                     culture = new CultureInfo(newName);
-
-#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-                    // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-                    // to be created, but will be "unknown" languages. We need to manually
-                    // ignore these.
-                    if (culture.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-                    {
-                        continue;
-                    }
-#endif
                     break;
                 }
                 catch (CultureNotFoundException)

--- a/src/ICU4N/Support/IntegerExtensions.cs
+++ b/src/ICU4N/Support/IntegerExtensions.cs
@@ -23,8 +23,8 @@ namespace ICU4N.Support
         /// <see cref="FlagsAttribute"/> and <paramref name="options"/> matches more than one enum symbol.</exception>
         public static T AsFlagsToEnum<T>(this int options, T defaultValue) where T : Enum
         {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            bool isFlagsEnum = typeof(T).GetTypeInfo().GetCustomAttribute<FlagsAttribute>(true) != null;
+#if FEATURE_TYPE_GETCUSTOMATTRIBUTE_GENERIC
+            bool isFlagsEnum = typeof(T).GetCustomAttribute<FlagsAttribute>(true) != null;
 #else
             bool isFlagsEnum = typeof(T).GetCustomAttributes(true).Any(a => typeof(FlagsAttribute).Equals(a.GetType()));
 #endif

--- a/src/ICU4N/Util/ULocale.cs
+++ b/src/ICU4N/Util/ULocale.cs
@@ -2236,17 +2236,7 @@
 //                    //                    try
 //                    //                    {
 //                    //                        CultureInfo loc = aLocale.ToLocale();
-//                    //#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-//                    //                        // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-//                    //                        // to be created, but will be "unknown" languages. We need to manually
-//                    //                        // ignore these.
-//                    //                        if (!loc.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-//                    //                        {
-//                    //#endif
 //                    //                            parent = LocaleUtility.Fallback(loc);
-//                    //#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-//                    //                        }
-//                    //#endif
 //                    //                    }
 //                    //                    // ICU4N: In .NET Framework and .NET Standard 2.x+, unknown cultures throw a 
 //                    //                    // CultureNotFoundException.
@@ -4661,16 +4651,6 @@
 //                try
 //                {
 //                    CultureInfo culture = new CultureInfo(newName);
-
-//                    //#if FEATURE_CULTUREINFO_UNKNOWNLANGUAGE
-//                    //                    // ICU4N: In .NET Standard 1.x, some invalid cultures are allowed
-//                    //                    // to be created, but will be "unknown" languages. We need to manually
-//                    //                    // ignore these.
-//                    //                    if (culture.EnglishName.StartsWith("Unknown Language", StringComparison.Ordinal))
-//                    //                    {
-//                    //                        return null;
-//                    //                    }
-//                    //#endif
 //                    return culture;
 //                }
 //                catch (CultureNotFoundException)

--- a/tests/ICU4N.Tests.Collation/Dev/Test/Util/ICUResourceBundleCollationTest.cs
+++ b/tests/ICU4N.Tests.Collation/Dev/Test/Util/ICUResourceBundleCollationTest.cs
@@ -65,11 +65,7 @@ namespace ICU4N.Dev.Test.Util
                };
 
             Logln("Testing functional equivalents for collation...");
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly assembly = typeof(Collator).GetTypeInfo().Assembly;
-#else
             Assembly assembly = typeof(Collator).Assembly;
-#endif
             getFunctionalEquivalentTestCases(ICUData.IcuCollationBaseName, assembly,
                COLLATION_RESNAME, COLLATION_KEYWORD, true, collCases);
         }

--- a/tests/ICU4N.Tests/Dev/Test/Lang/UCharacterSurrogateTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Lang/UCharacterSurrogateTest.cs
@@ -282,12 +282,7 @@ namespace ICU4N.Dev.Test.Lang
                 catch (Exception e)
                 {
                     //if (!exc.GetTypeInfo().isInstance(e))
-                    bool isAssignableFrom =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                        exc.GetTypeInfo().IsAssignableFrom(e.GetType());
-#else
-                        exc.IsAssignableFrom(e.GetType());
-#endif
+                    bool isAssignableFrom = exc.IsAssignableFrom(e.GetType());
                     if (!isAssignableFrom)
                     {
                         Warnln("bad exception " + Str(s, start, limit)
@@ -400,12 +395,7 @@ namespace ICU4N.Dev.Test.Lang
                 catch (Exception e)
                 {
                     //if (!exc.isInstance(e))
-                    bool isAssignableFrom =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                        exc.GetTypeInfo().IsAssignableFrom(e.GetType());
-#else
-                        exc.IsAssignableFrom(e.GetType());
-#endif
+                    bool isAssignableFrom = exc.IsAssignableFrom(e.GetType());
                     if (!isAssignableFrom)
                     {
                         Errln("bad exception "
@@ -426,12 +416,7 @@ namespace ICU4N.Dev.Test.Lang
                 catch (Exception e)
                 {
                     //if (!exc.isInstance(e))
-                    bool isAssignableFrom =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                        exc.GetTypeInfo().IsAssignableFrom(e.GetType());
-#else
-                        exc.IsAssignableFrom(e.GetType());
-#endif
+                    bool isAssignableFrom = exc.IsAssignableFrom(e.GetType());
                     if (!isAssignableFrom)
                     {
                         Errln("bad exception "

--- a/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBIMonkeyTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBIMonkeyTest.cs
@@ -866,11 +866,7 @@ namespace ICU4N.Dev.Test.Rbbi
                 String filePath = "ICU4N.Dev.Test.Rbbi.break_rules." + fileName;
                 try
                 {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                    Assembly assembly = typeof(RBBIMonkeyImpl).GetTypeInfo().Assembly;
-#else
                     Assembly assembly = typeof(RBBIMonkeyImpl).Assembly;
-#endif
                     @is = assembly.GetManifestResourceStream(filePath);
                     if (@is == null)
                     {

--- a/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBITestExtended.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Rbbi/RBBITestExtended.cs
@@ -49,11 +49,7 @@ namespace ICU4N.Dev.Test.Rbbi
             Stream @is = null;
             try
             {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                Assembly assembly = typeof(RBBITestExtended).GetTypeInfo().Assembly;
-#else
                 Assembly assembly = typeof(RBBITestExtended).Assembly;
-#endif
                 @is = assembly.GetManifestResourceStream("ICU4N.Dev.Test.Rbbi.rbbitst.txt");
                 if (@is == null)
                 {

--- a/tests/ICU4N.Tests/Dev/Test/StringPrep/NFS4StringPrep.cs
+++ b/tests/ICU4N.Tests/Dev/Test/StringPrep/NFS4StringPrep.cs
@@ -30,11 +30,7 @@ namespace ICU4N.Dev.Test.StringPrep
 
         private NFS4StringPrep()
         {
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly loader = typeof(NFS4StringPrep).GetTypeInfo().Assembly;
-#else
             Assembly loader = typeof(NFS4StringPrep).Assembly;
-#endif
             try
             {
                 string resourcePrefix = "ICU4N.Dev.Data.TestData.";

--- a/tests/ICU4N.Tests/Dev/Test/StringPrep/NamePrepTransform.cs
+++ b/tests/ICU4N.Tests/Dev/Test/StringPrep/NamePrepTransform.cs
@@ -23,11 +23,7 @@ namespace ICU4N.Dev.Test.StringPrep
         private NamePrepTransform()
         {
             // load the resource bundle
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly assembly = typeof(NamePrepTransform).GetTypeInfo().Assembly;
-#else
             Assembly assembly = typeof(NamePrepTransform).Assembly;
-#endif
             //ICUResourceBundle bundle = (ICUResourceBundle)ICUResourceBundle.GetBundleInstance("com/ibm/icu/dev/data/testdata", "idna_rules", assembly, true);
             ICUResourceBundle bundle = (ICUResourceBundle)ICUResourceBundle.GetBundleInstance("Dev/Data/TestData", "idna_rules", assembly, true);
             String mapRules = bundle.GetString("MapNoNormalization");

--- a/tests/ICU4N.Tests/Dev/Test/Util/ICUResourceBundleTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Util/ICUResourceBundleTest.cs
@@ -15,12 +15,7 @@ namespace ICU4N.Dev.Test.Util
 {
     public sealed class ICUResourceBundleTest : TestFmwk
     {
-        private static readonly Assembly testLoader =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            typeof(ICUResourceBundleTest).GetTypeInfo().Assembly; //ICUResourceBundleTest.class.getClassLoader();
-#else
-            typeof(ICUResourceBundleTest).Assembly; //ICUResourceBundleTest.class.getClassLoader();
-#endif
+        private static readonly Assembly testLoader = typeof(ICUResourceBundleTest).Assembly; //ICUResourceBundleTest.class.getClassLoader();
 
         // ICU4N TODO: Finish implementation
         //        [Test]
@@ -905,11 +900,7 @@ namespace ICU4N.Dev.Test.Util
 
             Logln("Testing functional equivalents for calendar...");
 
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly assembly = typeof(BreakIterator).GetTypeInfo().Assembly;
-#else
             Assembly assembly = typeof(BreakIterator).Assembly;
-#endif
             getFunctionalEquivalentTestCases(ICUData.IcuBaseName,
                                              //typeof(Calendar).GetTypeInfo().Assembly, // ICU4N TODO: If we ever port the Calendar type, we should reference it here
                                              assembly,

--- a/tests/ICU4N.Tests/Dev/Test/Util/Trie2Test.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Util/Trie2Test.cs
@@ -774,23 +774,13 @@ namespace ICU4N.Dev.Test.Util
         private void checkTrieRanges(String testName, String serializedName, bool withClone,
                 int[][] setRanges, int[][] checkRanges)
         {
-            string ns =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                typeof(Trie2Test).GetTypeInfo().Namespace;
-#else
-                typeof(Trie2Test).Namespace;
-#endif
+            string ns = typeof(Trie2Test).Namespace;
 
             // Run tests against Tries that were built by ICU4C and serialized.
             String fileName16 = ns + ".Trie2Test." + serializedName + ".16.tri2";
             String fileName32 = ns + ".Trie2Test." + serializedName + ".32.tri2";
 
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-            Assembly assembly = typeof(Trie2Test).GetTypeInfo().Assembly;
-#else
             Assembly assembly = typeof(Trie2Test).Assembly;
-#endif
-
             Stream @is = assembly.GetManifestResourceStream(fileName16);
             Trie2 trie16;
             try

--- a/tests/ICU4N.Tests/Dev/Test/Util/ULocaleTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Util/ULocaleTest.cs
@@ -4261,12 +4261,7 @@
 //            TestFmwk.Logln("uloc_getCLDRVersion() returned: '" + cldrVersion + "'");
 
 //            // why isn't this public for tests somewhere?
-//            Assembly testLoader =
-//#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-//                typeof(ICUResourceBundleTest).GetTypeInfo().Assembly;
-//#else
-//                typeof(ICUResourceBundleTest).Assembly;
-//#endif
+//            Assembly testLoader = typeof(ICUResourceBundleTest).Assembly;
 //            UResourceBundle bundle = UResourceBundle.GetBundleInstance("Dev/Data/TestData", ULocale.ROOT, testLoader);
 
 //            testExpect = VersionInfo.GetInstance(bundle.GetString("ExpectCLDRVersionAtLeast"));

--- a/tests/ICU4N.Tests/Support/Globalization/UCultureInfoTest.cs
+++ b/tests/ICU4N.Tests/Support/Globalization/UCultureInfoTest.cs
@@ -3992,12 +3992,7 @@ namespace ICU4N.Globalization
             TestFmwk.Logln("uloc_getCLDRVersion() returned: '" + cldrVersion + "'");
 
             // why isn't this public for tests somewhere?
-            Assembly testLoader =
-#if FEATURE_TYPEEXTENSIONS_GETTYPEINFO
-                typeof(ICUResourceBundleTest).GetTypeInfo().Assembly;
-#else
-                typeof(ICUResourceBundleTest).Assembly;
-#endif
+            Assembly testLoader = typeof(ICUResourceBundleTest).Assembly;
             UResourceBundle bundle = UResourceBundle.GetBundleInstance("Dev/Data/TestData", UCultureInfo.InvariantCulture, testLoader);
 
             testExpect = VersionInfo.GetInstance(bundle.GetString("ExpectCLDRVersionAtLeast"));


### PR DESCRIPTION
Fixes #72 

This removes the build features associated with .NET Standard 1.x and .NET Core 1.x.

- `NETSTANDARD1_X`
- `NETCOREAPP1_X`
- `FEATURE_CULTUREINFO_UNKNOWNLANGUAGE`
- `FEATURE_TYPEEXTENSIONS_GETTYPEINFO`

The other features defined in that section were also defined for .NET 4.5+, so they still remain in the project.

`FEATURE_TYPE_GETCUSTOMATTRIBUTE_GENERIC` was added to accommodate the faster generic `Type.GetCustomAttribute<T>()` method on supported platforms.