### PR TITLE
Rename numeric methods/types to conform with .NET conventions, #12

### DIFF
--- a/src/ICU4N/Impl/ICUResourceBundleImpl.cs
+++ b/src/ICU4N/Impl/ICUResourceBundleImpl.cs
@@ -39,9 +39,9 @@ namespace ICU4N.Impl
                 case UResourceType.Alias:
                     return GetAliasedResource(this, null, 0, _key, _resource, aliasesVisited, requested);
                 case UResourceType.Int32:
-                    return new ICUResourceBundleImpl.ResourceInt(this, _key, _resource);
+                    return new ICUResourceBundleImpl.ResourceInt32(this, _key, _resource);
                 case UResourceType.Int32Vector:
-                    return new ICUResourceBundleImpl.ResourceIntVector(this, _key, _resource);
+                    return new ICUResourceBundleImpl.ResourceInt32Vector(this, _key, _resource);
                 case UResourceType.Array:
                 case UResourceType.Array16:
                     return new ICUResourceBundleImpl.ResourceArray(this, _key, _resource);
@@ -74,7 +74,7 @@ namespace ICU4N.Impl
             {
             }
         }
-        private sealed class ResourceInt : ICUResourceBundleImpl // ICU4N TODO: API - rename ResourceInt32
+        private sealed class ResourceInt32 : ICUResourceBundleImpl
         {
             public override UResourceType Type => UResourceType.Int32;
 
@@ -87,7 +87,7 @@ namespace ICU4N.Impl
             {
                 return ICUResourceBundleReader.RES_GET_UINT(resource);
             }
-            internal ResourceInt(ICUResourceBundleImpl container, string key, int resource)
+            internal ResourceInt32(ICUResourceBundleImpl container, string key, int resource)
                     : base(container, key, resource)
             {
             }
@@ -118,7 +118,7 @@ namespace ICU4N.Impl
                 }
             }
         }
-        private sealed class ResourceIntVector : ICUResourceBundleImpl // ICU4N TODO: API Rename ResourceInt32Vector
+        private sealed class ResourceInt32Vector : ICUResourceBundleImpl
         {
             public override UResourceType Type => UResourceType.Int32Vector;
 
@@ -126,7 +126,7 @@ namespace ICU4N.Impl
             {
                 return wholeBundle.reader.GetInt32Vector(resource);
             }
-            internal ResourceIntVector(ICUResourceBundleImpl container, string key, int resource)
+            internal ResourceInt32Vector(ICUResourceBundleImpl container, string key, int resource)
                 : base(container, key, resource)
             {
             }

--- a/src/ICU4N/Impl/ICUResourceBundleReader.cs
+++ b/src/ICU4N/Impl/ICUResourceBundleReader.cs
@@ -269,7 +269,7 @@ namespace ICU4N.Impl
             // We need it so that we can read the key string bytes up front, for lookup performance.
 
             // read the variable-length indexes[] array
-            int indexes0 = GetIndexesInt(URES_INDEX_LENGTH);
+            int indexes0 = GetIndexesInt32(URES_INDEX_LENGTH);
             int indexLength = indexes0 & 0xff;
             if (indexLength <= URES_INDEX_MAX_TABLE_LENGTH)
             {
@@ -277,7 +277,7 @@ namespace ICU4N.Impl
             }
             int bundleTop;
             if (dataLength < ((1 + indexLength) << 2) ||
-                    dataLength < ((bundleTop = GetIndexesInt(URES_INDEX_BUNDLE_TOP)) << 2))
+                    dataLength < ((bundleTop = GetIndexesInt32(URES_INDEX_BUNDLE_TOP)) << 2))
             {
                 throw new ICUException("not enough bytes");
             }
@@ -295,7 +295,7 @@ namespace ICU4N.Impl
             {
                 // determine if this resource bundle falls back to a parent bundle
                 // along normal locale ID fallback
-                int att = GetIndexesInt(URES_INDEX_ATTRIBUTES);
+                int att = GetIndexesInt32(URES_INDEX_ATTRIBUTES);
                 noFallback = (att & URES_ATT_NO_FALLBACK) != 0;
                 isPoolBundle = (att & URES_ATT_IS_POOL_BUNDLE) != 0;
                 usesPoolBundle = (att & URES_ATT_USES_POOL_BUNDLE) != 0;
@@ -304,7 +304,7 @@ namespace ICU4N.Impl
             }
 
             int keysBottom = 1 + indexLength;
-            int keysTop = GetIndexesInt(URES_INDEX_KEYS_TOP);
+            int keysTop = GetIndexesInt32(URES_INDEX_KEYS_TOP);
             if (keysTop > keysBottom)
             {
                 // Deserialize the key strings up front.
@@ -329,7 +329,7 @@ namespace ICU4N.Impl
             // Read the array of 16-bit units.
             if (indexLength > URES_INDEX_16BIT_TOP)
             {
-                int _16BitTop = GetIndexesInt(URES_INDEX_16BIT_TOP);
+                int _16BitTop = GetIndexesInt32(URES_INDEX_16BIT_TOP);
                 if (_16BitTop > keysTop)
                 {
                     int num16BitUnits = (_16BitTop - keysTop) * 2;
@@ -350,7 +350,7 @@ namespace ICU4N.Impl
 
             if (indexLength > URES_INDEX_POOL_CHECKSUM)
             {
-                poolCheckSum = GetIndexesInt(URES_INDEX_POOL_CHECKSUM);
+                poolCheckSum = GetIndexesInt32(URES_INDEX_POOL_CHECKSUM);
             }
 
             if (!isPoolBundle || b16BitUnits.Length > 1)
@@ -362,7 +362,7 @@ namespace ICU4N.Impl
             bytes.Position = 0;
         }
 
-        private int GetIndexesInt(int i)
+        private int GetIndexesInt32(int i)
         {
             return bytes.GetInt32((1 + i) << 2);
         }

--- a/src/ICU4N/Impl/Number/DecimalQuantity_AbstractBCD.cs
+++ b/src/ICU4N/Impl/Number/DecimalQuantity_AbstractBCD.cs
@@ -256,9 +256,9 @@ namespace ICU4N.Numerics
 
             return operand switch
             {
-                Operand.i => ToLong(),
-                Operand.f => ToFractionLong(true),
-                Operand.t => ToFractionLong(false),
+                Operand.i => ToInt64(),
+                Operand.f => ToFractionInt64(true),
+                Operand.t => ToFractionInt64(false),
                 Operand.v => FractionCount,
                 Operand.w => FractionCountWithoutTrailingZeros,
                 _ => Math.Abs(ToDouble()),
@@ -332,7 +332,7 @@ namespace ICU4N.Numerics
 
         public abstract int MaxRepresentableDigits { get; }
 
-        public void SetToInt(int n)
+        public void SetToInt32(int n)
         {
             SetBcdToZero();
             flags = 0;
@@ -343,24 +343,24 @@ namespace ICU4N.Numerics
             }
             if (n != 0)
             {
-                SetToIntImpl(n);
+                SetToInt32Impl(n);
                 Compact();
             }
         }
 
-        private void SetToIntImpl(int n)
+        private void SetToInt32Impl(int n)
         {
             if (n == int.MinValue)
             {
-                ReadLongToBcd(-(long)n);
+                ReadInt64ToBcd(-(long)n);
             }
             else
             {
-                ReadIntToBcd(n);
+                ReadInt32ToBcd(n);
             }
         }
 
-        public void SetToLong(long n)
+        public void SetToInt64(long n)
         {
             SetBcdToZero();
             flags = 0;
@@ -371,12 +371,12 @@ namespace ICU4N.Numerics
             }
             if (n != 0)
             {
-                SetToLongImpl(n);
+                SetToInt64Impl(n);
                 Compact();
             }
         }
 
-        private void SetToLongImpl(long n)
+        private void SetToInt64Impl(long n)
         {
             if (n == long.MinValue)
             {
@@ -384,11 +384,11 @@ namespace ICU4N.Numerics
             }
             else if (n <= int.MaxValue)
             {
-                ReadIntToBcd((int)n);
+                ReadInt32ToBcd((int)n);
             }
             else
             {
-                ReadLongToBcd(n);
+                ReadInt64ToBcd(n);
             }
         }
 
@@ -413,11 +413,11 @@ namespace ICU4N.Numerics
             int bitLength = n.BitLength;
             if (bitLength < 32)
             {
-                ReadIntToBcd(n.ToInt32());
+                ReadInt32ToBcd(n.ToInt32());
             }
             else if (bitLength < 64)
             {
-                ReadLongToBcd(n.ToInt64());
+                ReadInt64ToBcd(n.ToInt64());
             }
             else
             {
@@ -477,7 +477,7 @@ namespace ICU4N.Numerics
             // Not all integers can be represented exactly for exponent > 52
             if (exponent <= 52 && (long)n == n)
             {
-                SetToLongImpl((long)n);
+                SetToInt64Impl((long)n);
                 return;
             }
 
@@ -500,7 +500,7 @@ namespace ICU4N.Numerics
             long result = (long)Math.Ceiling(n); // ICU4N: Changed from Math.Round() to Math.Ceiling (ToPositiveInfinity equivalent, the Java default)
             if (result != 0)
             {
-                SetToLongImpl(result);
+                SetToInt64Impl(result);
                 scale -= fracLength;
             }
         }
@@ -526,14 +526,14 @@ namespace ICU4N.Numerics
                 // Case 1: Exponential notation.
                 Debug.Assert(dstr.IndexOf('.') == 1);
                 int expPos = dstr.IndexOf('E');
-                SetToLongImpl(long.Parse(StringHelper.Concat(dstr.AsSpan(0, 1), dstr.AsSpan(2, expPos - 2)), CultureInfo.InvariantCulture)); // ICU4N: Corrected 2nd arg.
+                SetToInt64Impl(long.Parse(StringHelper.Concat(dstr.AsSpan(0, 1), dstr.AsSpan(2, expPos - 2)), CultureInfo.InvariantCulture)); // ICU4N: Corrected 2nd arg.
                 scale += J2N.Numerics.Int32.Parse(dstr.AsSpan(expPos + 1), NumberStyle.Integer, CultureInfo.InvariantCulture) - (expPos - 1) + 1;
             }
             else if (dstr[0] == '0')
             {
                 // Case 2: Fraction-only number.
                 Debug.Assert(dstr.IndexOf('.') == 1);
-                SetToLongImpl(J2N.Numerics.Int64.Parse(dstr.AsSpan(2), NumberStyle.None, CultureInfo.InvariantCulture));
+                SetToInt64Impl(J2N.Numerics.Int64.Parse(dstr.AsSpan(2), NumberStyle.None, CultureInfo.InvariantCulture));
                 scale += 2 - dstr.Length;
             }
             else if (dstr[dstr.Length - 1] == '0')
@@ -543,14 +543,14 @@ namespace ICU4N.Numerics
                 // before the approximate double logic is performed.
                 Debug.Assert(dstr.IndexOf('.') == dstr.Length - 2);
                 Debug.Assert(dstr.Length - 2 <= 18);
-                SetToLongImpl(J2N.Numerics.Int64.Parse(dstr.AsSpan(0, dstr.Length - 2), NumberStyle.None, CultureInfo.InvariantCulture)); // ICU4N: Checked 2nd arg
+                SetToInt64Impl(J2N.Numerics.Int64.Parse(dstr.AsSpan(0, dstr.Length - 2), NumberStyle.None, CultureInfo.InvariantCulture)); // ICU4N: Checked 2nd arg
                                                                                                                              // no need to adjust scale
             }
             else
             {
                 // Case 4: Number with both a fraction and an integer.
                 int decimalPos = dstr.IndexOf('.');
-                SetToLongImpl(long.Parse(StringHelper.Concat(dstr.AsSpan(0, decimalPos), dstr.AsSpan(decimalPos + 1)), CultureInfo.InvariantCulture)); // ICU4N: Checked 2nd arg
+                SetToInt64Impl(long.Parse(StringHelper.Concat(dstr.AsSpan(0, decimalPos), dstr.AsSpan(decimalPos + 1)), CultureInfo.InvariantCulture)); // ICU4N: Checked 2nd arg
                 scale += decimalPos - dstr.Length + 1;
             }
 
@@ -608,7 +608,7 @@ namespace ICU4N.Numerics
          *
          * @return A double representation of the internal BCD.
          */
-        protected virtual long ToLong()
+        protected virtual long ToInt64()
         {
             long result = 0L;
             for (int magnitude = scale + precision - 1; magnitude >= 0; magnitude--)
@@ -623,7 +623,7 @@ namespace ICU4N.Numerics
          * For example, if we represent the number "1.20" (including optional and required digits), then
          * this function returns "20" if includeTrailingZeros is true or "2" if false.
          */
-        protected long ToFractionLong(bool includeTrailingZeros)
+        protected long ToFractionInt64(bool includeTrailingZeros)
         {
             long result = 0L;
             int magnitude = -1;
@@ -1034,7 +1034,7 @@ namespace ICU4N.Numerics
          *
          * @param n The value to consume.
          */
-        protected abstract void ReadIntToBcd(int input);
+        protected abstract void ReadInt32ToBcd(int input);
 
         /**
          * Sets the internal BCD state to represent the value in the given long. The long is guaranteed to
@@ -1042,7 +1042,7 @@ namespace ICU4N.Numerics
          *
          * @param n The value to consume.
          */
-        protected abstract void ReadLongToBcd(long input);
+        protected abstract void ReadInt64ToBcd(long input);
 
         /**
          * Sets the internal BCD state to represent the value in the given BigInteger. The BigInteger is

--- a/src/ICU4N/Impl/Number/DecimalQuantity_DualStorageBCD.cs
+++ b/src/ICU4N/Impl/Number/DecimalQuantity_DualStorageBCD.cs
@@ -42,12 +42,12 @@ namespace ICU4N.Numerics
 
         public DecimalQuantity_DualStorageBCD(long input)
         {
-            SetToLong(input);
+            SetToInt64(input);
         }
 
         public DecimalQuantity_DualStorageBCD(int input)
         {
-            SetToInt(input);
+            SetToInt32(input);
         }
 
         public DecimalQuantity_DualStorageBCD(double input)
@@ -74,11 +74,11 @@ namespace ICU4N.Numerics
         {
             if (number is Long)
             {
-                SetToLong(number.ToInt64());
+                SetToInt64(number.ToInt64());
             }
             else if (number is Integer)
             {
-                SetToInt(number.ToInt32());
+                SetToInt32(number.ToInt32());
             }
             else if (number is Double)
             {
@@ -210,7 +210,7 @@ namespace ICU4N.Numerics
             origDelta = 0;
         }
 
-        protected override void ReadIntToBcd(int n)
+        protected override void ReadInt32ToBcd(int n)
         {
             //assert n != 0;
             if (n == 0)
@@ -228,7 +228,7 @@ namespace ICU4N.Numerics
             precision = 16 - i;
         }
 
-        protected override void ReadLongToBcd(long n)
+        protected override void ReadInt64ToBcd(long n)
         {
             //assert n != 0;
             if (n == 0)

--- a/src/ICU4N/Impl/Trie2.cs
+++ b/src/ICU4N/Impl/Trie2.cs
@@ -364,7 +364,7 @@ namespace ICU4N.Impl
                 int hash = InitHash();
                 foreach (Trie2Range r in this)
                 {
-                    hash = HashInt(hash, r.GetHashCode());
+                    hash = HashInt32(hash, r.GetHashCode());
                 }
                 if (hash == 0)
                 {
@@ -1119,7 +1119,7 @@ namespace ICU4N.Impl
             return h;
         }
 
-        internal static int HashInt(int h, int i)
+        internal static int HashInt32(int h, int i)
         {
             h = Trie2.HashByte(h, i & 255);
             h = Trie2.HashByte(h, (i >> 8) & 255);
@@ -1165,7 +1165,7 @@ namespace ICU4N.Impl
             int h = Trie2.InitHash();
             h = Trie2.HashUChar32(h, StartCodePoint);
             h = Trie2.HashUChar32(h, EndCodePoint);
-            h = Trie2.HashInt(h, Value);
+            h = Trie2.HashInt32(h, Value);
             h = Trie2.HashByte(h, IsLeadSurrogate ? 1 : 0);
             return h;
         }

--- a/src/ICU4N/Impl/Trie2Writable.cs
+++ b/src/ICU4N/Impl/Trie2Writable.cs
@@ -696,7 +696,7 @@ namespace ICU4N.Impl
 
         /* compaction --------------------------------------------------------------- */
 
-        private bool EqualInt(int[] a, int s, int t, int length)
+        private bool EqualInt32(int[] a, int s, int t, int length)
         {
             for (int i = 0; i < length; i++)
             {
@@ -718,7 +718,7 @@ namespace ICU4N.Impl
 
             for (block = 0; block <= index2Length; ++block)
             {
-                if (EqualInt(index2, block, otherBlock, UTRIE2_INDEX_2_BLOCK_LENGTH))
+                if (EqualInt32(index2, block, otherBlock, UTRIE2_INDEX_2_BLOCK_LENGTH))
                 {
                     return block;
                 }
@@ -736,7 +736,7 @@ namespace ICU4N.Impl
 
             for (block = 0; block <= dataLength; block += UTRIE2_DATA_GRANULARITY)
             {
-                if (EqualInt(data, block, otherBlock, blockLength))
+                if (EqualInt32(data, block, otherBlock, blockLength))
                 {
                     return block;
                 }
@@ -911,7 +911,7 @@ namespace ICU4N.Impl
                 /* see if the beginning of this block can be overlapped with the end of the previous block */
                 /* look for maximum overlap (modulo granularity) with the previous, adjacent block */
                 for (overlap = blockLength - UTRIE2_DATA_GRANULARITY;
-                    overlap > 0 && !EqualInt(data, (newStart - overlap), start, overlap);
+                    overlap > 0 && !EqualInt32(data, (newStart - overlap), start, overlap);
                     overlap -= UTRIE2_DATA_GRANULARITY) { }
 
                 if (overlap > 0 || newStart < start)
@@ -1010,7 +1010,7 @@ namespace ICU4N.Impl
                 /* see if the beginning of this block can be overlapped with the end of the previous block */
                 /* look for maximum overlap with the previous, adjacent block */
                 for (overlap = UTRIE2_INDEX_2_BLOCK_LENGTH - 1;
-                    overlap > 0 && !EqualInt(index2, newStart - overlap, start, overlap);
+                    overlap > 0 && !EqualInt32(index2, newStart - overlap, start, overlap);
                     --overlap) { }
 
                 if (overlap > 0 || newStart < start)

--- a/src/ICU4N/Support/Numerics/BigMath/BigDecimal.Math.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/BigDecimal.Math.cs
@@ -74,13 +74,13 @@ namespace ICU4N.Numerics.BigMath
             var largerSignum = larger.Sign;
             if (largerSignum == smaller.Sign)
             {
-                tempBi = Multiplication.MultiplyByPositiveInt(larger.UnscaledValue, 10) +
+                tempBi = Multiplication.MultiplyByPositiveInt32(larger.UnscaledValue, 10) +
                          BigInteger.GetInstance(largerSignum);
             }
             else
             {
                 tempBi = larger.UnscaledValue - BigInteger.GetInstance(largerSignum);
-                tempBi = Multiplication.MultiplyByPositiveInt(tempBi, 10) +
+                tempBi = Multiplication.MultiplyByPositiveInt32(tempBi, 10) +
                          BigInteger.GetInstance(largerSignum * 9);
             }
             // Rounding the improved adding 
@@ -260,13 +260,13 @@ namespace ICU4N.Numerics.BigMath
                     BigInteger tempBI;
                     if (thisSignum != subtrahend.Sign)
                     {
-                        tempBI = Multiplication.MultiplyByPositiveInt(value.UnscaledValue, 10) +
+                        tempBI = Multiplication.MultiplyByPositiveInt32(value.UnscaledValue, 10) +
                                  BigInteger.GetInstance(thisSignum);
                     }
                     else
                     {
                         tempBI = value.UnscaledValue - BigInteger.GetInstance(thisSignum);
-                        tempBI = Multiplication.MultiplyByPositiveInt(tempBI, 10) +
+                        tempBI = Multiplication.MultiplyByPositiveInt32(tempBI, 10) +
                                  BigInteger.GetInstance(thisSignum * 9);
                     }
                     // Rounding the improved subtracting
@@ -310,9 +310,9 @@ namespace ICU4N.Numerics.BigMath
              * this x multiplicand = [ s1 * s2 , s1 + s2 ] */
             if (value.BitLength + multiplicand.BitLength < 64 && value.SmallValue != long.MinValue && multiplicand.SmallValue != long.MinValue)
             {
-                return BigDecimal.GetInstance(value.SmallValue * multiplicand.SmallValue, ToIntScale(newScale));
+                return BigDecimal.GetInstance(value.SmallValue * multiplicand.SmallValue, ToInt32Scale(newScale));
             }
-            return new BigDecimal(value.UnscaledValue * multiplicand.UnscaledValue, ToIntScale(newScale));
+            return new BigDecimal(value.UnscaledValue * multiplicand.UnscaledValue, ToInt32Scale(newScale));
         }
 
         /**
@@ -445,7 +445,7 @@ namespace ICU4N.Numerics.BigMath
                 // 63 in order to avoid out of long after <<1
                 long rem = remainder.ToInt64();
                 long divisor = scaledDivisor.ToInt64();
-                compRem = LongCompareTo(System.Math.Abs(rem) << 1, System.Math.Abs(divisor));
+                compRem = Int64CompareTo(System.Math.Abs(rem) << 1, System.Math.Abs(divisor));
                 // To look if there is a carry
                 compRem = RoundingBehavior(BigInteger.TestBit(quotient, 0) ? 1 : 0,
                     sign * (5 + compRem), roundingMode);
@@ -481,7 +481,7 @@ namespace ICU4N.Numerics.BigMath
             {
                 // Checking if:  remainder * 2 >= scaledDivisor
                 int compRem; // 'compare to remainder'
-                compRem = LongCompareTo(Math.Abs(remainder) << 1, Math.Abs(scaledDivisor));
+                compRem = Int64CompareTo(Math.Abs(remainder) << 1, Math.Abs(scaledDivisor));
                 // To look if there is a carry
                 quotient += RoundingBehavior(((int)quotient) & 1, sign * (5 + compRem), roundingMode);
             }
@@ -603,7 +603,7 @@ namespace ICU4N.Numerics.BigMath
                 p = -p;
             }
             // Checking if the new scale is out of range
-            newScale = ToIntScale(diffScale + Math.Max(k, l));
+            newScale = ToInt32Scale(diffScale + Math.Max(k, l));
             // k >= 0  and  l >= 0  implies that  k - l  is in the 32-bit range
             i = k - l;
 
@@ -702,7 +702,7 @@ namespace ICU4N.Numerics.BigMath
                 }
             }
             // To perform rounding
-            return new BigDecimal(integerQuot, ToIntScale(newScale), mc);
+            return new BigDecimal(integerQuot, ToInt32Scale(newScale), mc);
         }
 
         /**
@@ -788,7 +788,7 @@ namespace ICU4N.Numerics.BigMath
             }
             return ((integralValue.Sign == 0)
                 ? BigDecimal.GetZeroScaledBy(newScale)
-                : new BigDecimal(integralValue, BigDecimal.ToIntScale(newScale)));
+                : new BigDecimal(integralValue, BigDecimal.ToInt32Scale(newScale)));
         }
 
         /**
@@ -925,7 +925,7 @@ namespace ICU4N.Numerics.BigMath
                 // math.06=Division impossible
                 throw new ArithmeticException(Messages.math06); //$NON-NLS-1$
             }
-            integralValue.Scale = ToIntScale(newScale);
+            integralValue.Scale = ToInt32Scale(newScale);
             integralValue.SetUnscaledValue(strippedBI);
             return integralValue;
         }
@@ -1087,7 +1087,7 @@ namespace ICU4N.Numerics.BigMath
             // Let be: this = [u,s]   so:  this^n = [u^n, s*n]
             return ((number.IsZero)
                 ? GetZeroScaledBy(newScale)
-                : new BigDecimal(BigInteger.Pow(number.UnscaledValue, n), ToIntScale(newScale)));
+                : new BigDecimal(BigInteger.Pow(number.UnscaledValue, n), ToInt32Scale(newScale)));
         }
 
         /**
@@ -1403,9 +1403,9 @@ namespace ICU4N.Numerics.BigMath
             {
                 if (number.BitLength < 64)
                 {
-                    return BigDecimal.GetInstance(number.SmallValue, ToIntScale(newScale));
+                    return BigDecimal.GetInstance(number.SmallValue, ToInt32Scale(newScale));
                 }
-                return new BigDecimal(number.UnscaledValue, ToIntScale(newScale));
+                return new BigDecimal(number.UnscaledValue, ToInt32Scale(newScale));
             }
             if (-newScale < LongTenPow.Length &&
                 number.BitLength + LongTenPowBitLength[(int)-newScale] < 64)
@@ -1459,10 +1459,10 @@ namespace ICU4N.Numerics.BigMath
                     return GetZeroScaledBy(newScale);
                 }
 
-                return BigDecimal.GetInstance(number.SmallValue, ToIntScale(newScale));
+                return BigDecimal.GetInstance(number.SmallValue, ToInt32Scale(newScale));
             }
 
-            return new BigDecimal(number.UnscaledValue, ToIntScale(newScale));
+            return new BigDecimal(number.UnscaledValue, ToInt32Scale(newScale));
         }
 
         /**
@@ -1516,7 +1516,7 @@ namespace ICU4N.Numerics.BigMath
                     i = 1;
                 }
             }
-            return new BigDecimal(strippedBI, ToIntScale(newScale));
+            return new BigDecimal(strippedBI, ToInt32Scale(newScale));
         }
 
 

--- a/src/ICU4N/Support/Numerics/BigMath/BigDecimal.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/BigDecimal.cs
@@ -973,12 +973,12 @@ namespace ICU4N.Numerics.BigMath
                 }
             }
             // To update all internal fields
-            _scale = ToIntScale(newScale);
+            _scale = ToInt32Scale(newScale);
             _precision = mcPrecision;
             SetUnscaledValue(integer);
         }
 
-        internal static int LongCompareTo(long value1, long value2)
+        internal static int Int64CompareTo(long value1, long value2)
         {
             return value1 > value2 ? 1 : (value1 < value2 ? -1 : 0);
         }
@@ -1006,7 +1006,7 @@ namespace ICU4N.Numerics.BigMath
             if (fraction != 0)
             {
                 // To check if the discarded fraction >= 0.5
-                compRem = LongCompareTo(Math.Abs(fraction) << 1, sizeOfFraction);
+                compRem = Int64CompareTo(Math.Abs(fraction) << 1, sizeOfFraction);
                 // To look if there is a carry
                 integer += RoundingBehavior(((int)integer) & 1, Math.Sign(fraction) * (5 + compRem),
                     mc.RoundingMode);
@@ -1018,7 +1018,7 @@ namespace ICU4N.Numerics.BigMath
                 }
             }
             // To update all internal fields
-            _scale = ToIntScale(newScale);
+            _scale = ToInt32Scale(newScale);
             _precision = mc.Precision;
             smallValue = integer;
             _bitLength = CalcBitLength(integer);
@@ -1137,7 +1137,7 @@ namespace ICU4N.Numerics.BigMath
         *             fit in {@code int} type
         * @see #scale
         */
-        internal static int ToIntScale(long longScale)
+        internal static int ToInt32Scale(long longScale)
         {
             if (longScale < int.MinValue)
                 // math.09=Overflow

--- a/src/ICU4N/Support/Numerics/BigMath/BigInteger.Math.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/BigInteger.Math.cs
@@ -497,7 +497,7 @@ namespace ICU4N.Numerics.BigMath
             int[] divisorDigits = divisor.digits;
             if (divisorLen == 1)
             {
-                var values = Division.DivideAndRemainderByInteger(dividend, divisorDigits[0], divisorSign);
+                var values = Division.DivideAndRemainderByInt32(dividend, divisorDigits[0], divisorSign);
                 remainder = values[1];
                 return values[0];
             }
@@ -585,7 +585,7 @@ namespace ICU4N.Numerics.BigMath
             int resSign = ((thisSign == divisorSign) ? 1 : -1);
             if (divisorLen == 1)
             {
-                Division.DivideArrayByInt(resDigits, dividend.digits, thisLen,
+                Division.DivideArrayByInt32(resDigits, dividend.digits, thisLen,
                     divisor.digits[0]);
             }
             else
@@ -635,7 +635,7 @@ namespace ICU4N.Numerics.BigMath
             int[] resDigits = new int[resLength];
             if (resLength == 1)
             {
-                resDigits[0] = Division.RemainderArrayByInt(dividend.digits, thisLen,
+                resDigits[0] = Division.RemainderArrayByInt32(dividend.digits, thisLen,
                     divisor.digits[0]);
             }
             else

--- a/src/ICU4N/Support/Numerics/BigMath/Conversion.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/Conversion.cs
@@ -99,7 +99,7 @@ namespace ICU4N.Numerics.BigMath
                 {
                     // divide the array of digits by bigRadix and convert remainders
                     // to CharHelpers collecting them in the char array
-                    resDigit = Division.DivideArrayByInt(temp, temp, tempLen, bigRadix);
+                    resDigit = Division.DivideArrayByInt32(temp, temp, tempLen, bigRadix);
                     int previous = currentChar;
                     do
                     {

--- a/src/ICU4N/Support/Numerics/BigMath/Division.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/Division.cs
@@ -94,7 +94,7 @@ namespace ICU4N.Numerics.BigMath
                 else
                 {
                     long product = (((normA[j] & 0xffffffffL) << 32) + (normA[j - 1] & 0xffffffffL));
-                    long res = Division.DivideLongByInt(product, firstDivisorDigit);
+                    long res = Division.DivideInt64ByInt32(product, firstDivisorDigit);
                     guessDigit = (int)res; // the quotient of divideLongByInt
                     int rem = (int)(res >> 32); // the remainder of
                                                 // divideLongByInt
@@ -189,7 +189,7 @@ namespace ICU4N.Numerics.BigMath
         * @param divisor the divisor
         * @return remainder
         */
-        public static int DivideArrayByInt(int[] dest, int[] src, int srcLength, int divisor)
+        public static int DivideArrayByInt32(int[] dest, int[] src, int srcLength, int divisor)
         {
             long rem = 0;
             long bLong = divisor & 0xffffffffL;
@@ -249,14 +249,14 @@ namespace ICU4N.Numerics.BigMath
         * @param divisor the divisor
         * @return remainder
         */
-        public static int RemainderArrayByInt(int[] src, int srcLength, int divisor)
+        public static int RemainderArrayByInt32(int[] src, int srcLength, int divisor)
         {
             long result = 0;
 
             for (int i = srcLength - 1; i >= 0; i--)
             {
                 long temp = (result << 32) + (src[i] & 0xffffffffL);
-                long res = DivideLongByInt(temp, divisor);
+                long res = DivideInt64ByInt32(temp, divisor);
                 result = (int)(res >> 32);
             }
             return (int)result;
@@ -272,7 +272,7 @@ namespace ICU4N.Numerics.BigMath
         */
         public static int Remainder(BigInteger dividend, int divisor)
         {
-            return RemainderArrayByInt(dividend.Digits, dividend.numberLength, divisor);
+            return RemainderArrayByInt32(dividend.Digits, dividend.numberLength, divisor);
         }
 
         /**
@@ -284,7 +284,7 @@ namespace ICU4N.Numerics.BigMath
         * @return the long value containing the unsigned integer remainder in the
         *         left half and the unsigned integer quotient in the right half
         */
-        private static long DivideLongByInt(long a, int b)
+        private static long DivideInt64ByInt32(long a, int b)
         {
             long quot;
             long rem;
@@ -336,7 +336,7 @@ namespace ICU4N.Numerics.BigMath
         * 
         * @return an array of the form {@code [quotient, remainder]}.
         */
-        public static BigInteger[] DivideAndRemainderByInteger(BigInteger val, int divisor, int divisorSign)
+        public static BigInteger[] DivideAndRemainderByInt32(BigInteger val, int divisor, int divisorSign)
         {
             // res[0] is a quotient and res[1] is a remainder:
             int[] valDigits = val.Digits;
@@ -362,7 +362,7 @@ namespace ICU4N.Numerics.BigMath
             int[] quotientDigits = new int[quotientLength];
             int[] remainderDigits;
             remainderDigits = new int[] {
-                Division.DivideArrayByInt(
+                Division.DivideArrayByInt32(
                     quotientDigits,
                     valDigits,
                     valLen,

--- a/src/ICU4N/Support/Numerics/BigMath/Multiplication.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/Multiplication.cs
@@ -260,11 +260,11 @@ namespace ICU4N.Numerics.BigMath
 
             if (aLen == 1)
             {
-                resDigits[bLen] = MultiplyByInt(resDigits, bDigits, bLen, aDigits[0]);
+                resDigits[bLen] = MultiplyByInt32(resDigits, bDigits, bLen, aDigits[0]);
             }
             else if (bLen == 1)
             {
-                resDigits[aLen] = MultiplyByInt(resDigits, aDigits, aLen, bDigits[0]);
+                resDigits[aLen] = MultiplyByInt32(resDigits, aDigits, aLen, bDigits[0]);
             }
             else
             {
@@ -302,7 +302,7 @@ namespace ICU4N.Numerics.BigMath
         * @param factor the multiplier
         * @return the top digit of production
         */
-        private static int MultiplyByInt(int[] res, int[] a, int aSize, int factor)
+        private static int MultiplyByInt32(int[] res, int[] a, int aSize, int factor)
         {
             long carry = 0;
             for (int i = 0; i < aSize; i++)
@@ -322,9 +322,9 @@ namespace ICU4N.Numerics.BigMath
         * @param factor the multiplier
         * @return the top digit of production
         */
-        public static int MultiplyByInt(int[] a, int aSize, int factor)
+        public static int MultiplyByInt32(int[] a, int aSize, int factor)
         {
-            return MultiplyByInt(a, a, aSize, factor);
+            return MultiplyByInt32(a, a, aSize, factor);
         }
 
         /**
@@ -333,7 +333,7 @@ namespace ICU4N.Numerics.BigMath
         * @param factor a positive {@code int} number
         * @return {@code val * factor}
         */
-        public static BigInteger MultiplyByPositiveInt(BigInteger val, int factor)
+        public static BigInteger MultiplyByPositiveInt32(BigInteger val, int factor)
         {
             int resSign = val.Sign;
             if (resSign == 0)
@@ -356,7 +356,7 @@ namespace ICU4N.Numerics.BigMath
             int resLength = aNumberLength + 1;
             int[] resDigits = new int[resLength];
 
-            resDigits[aNumberLength] = MultiplyByInt(resDigits, aDigits, aNumberLength, factor);
+            resDigits[aNumberLength] = MultiplyByInt32(resDigits, aDigits, aNumberLength, factor);
             BigInteger result = new BigInteger(resSign, resLength, resDigits);
             result.CutOffLeadingZeroes();
             return result;
@@ -439,7 +439,7 @@ namespace ICU4N.Numerics.BigMath
         {
             // PRE: exp >= 0
             return ((exp < TenPows.Length)
-            ? MultiplyByPositiveInt(val, TenPows[(int)exp])
+            ? MultiplyByPositiveInt32(val, TenPows[(int)exp])
             : val * PowerOf10(exp));
         }
 
@@ -534,7 +534,7 @@ namespace ICU4N.Numerics.BigMath
             // PRE: exp >= 0
             if (exp < FivePows.Length)
             {
-                return MultiplyByPositiveInt(val, FivePows[exp]);
+                return MultiplyByPositiveInt32(val, FivePows[exp]);
             }
             else if (exp < BigFivePows.Length)
             {

--- a/src/ICU4N/Support/Numerics/BigMath/ParseNumbers.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/ParseNumbers.cs
@@ -314,7 +314,7 @@ namespace ICU4N.Numerics.BigMath
                 if (substrStart == grabNumbersStart)
                     return ParsingStatus.Format_UnparsibleDigit;
 
-                newDigit = Multiplication.MultiplyByInt(digits, digitIndex, bigRadix);
+                newDigit = Multiplication.MultiplyByInt32(digits, digitIndex, bigRadix);
                 newDigit += Elementary.InplaceAdd(digits, digitIndex, bigRadixDigit);
                 digits[digitIndex++] = newDigit;
             }

--- a/src/ICU4N/Support/Numerics/BigMath/Primality.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/Primality.cs
@@ -244,7 +244,7 @@ namespace ICU4N.Numerics.BigMath
             // To check if 'n' is divisible by some prime of the table
             for (int j = 1; j < primes.Length; j++)
             {
-                if (Division.RemainderArrayByInt(n.Digits, n.numberLength, primes[j]) == 0)
+                if (Division.RemainderArrayByInt32(n.Digits, n.numberLength, primes[j]) == 0)
                 {
                     return false;
                 }

--- a/tests/ICU4N.Tests.Collation/Dev/Test/Collate/Counter.cs
+++ b/tests/ICU4N.Tests.Collation/Dev/Test/Collate/Counter.cs
@@ -8,7 +8,7 @@ namespace ICU4N.Dev.Test.Collate
 {
     public class Counter<T> : IEnumerable<T>, IComparable<Counter<T>>
     {
-        readonly IDictionary<T, RWLong> map;
+        readonly IDictionary<T, RWInt64> map;
         readonly IComparer<T> comparer;
 
         public Counter()
@@ -21,27 +21,27 @@ namespace ICU4N.Dev.Test.Collate
             if (this.comparer != null)
             {
                 this.comparer = comparer;
-                map = new SortedDictionary<T, RWLong>(this.comparer);
+                map = new SortedDictionary<T, RWInt64>(this.comparer);
             }
             else
             {
                 //map = new LinkedHashMap<T, RWLong>();
-                map = new Dictionary<T, RWLong>();
+                map = new Dictionary<T, RWInt64>();
             }
         }
 
-        public sealed class RWLong : IComparable<RWLong>
+        public sealed class RWInt64 : IComparable<RWInt64>
         {
             // the uniqueCount ensures that two different RWIntegers will always be different
             static int uniqueCount;
             public long value;
             private readonly int forceUnique;
-            internal RWLong()
+            internal RWInt64()
             {
                 forceUnique = Interlocked.Increment(ref uniqueCount) - 1; // make thread-safe
             }
 
-            public int CompareTo(RWLong that)
+            public int CompareTo(RWInt64 that)
             {
                 if (that.value < value) return -1;
                 if (that.value > value) return 1;
@@ -57,8 +57,8 @@ namespace ICU4N.Dev.Test.Collate
 
         public Counter<T> Add(T obj, long countValue)
         {
-            if (!map.TryGetValue(obj, out RWLong count))
-                map[obj] = count = new RWLong();
+            if (!map.TryGetValue(obj, out RWInt64 count))
+                map[obj] = count = new RWInt64();
 
             count.value += countValue;
             return this;
@@ -71,7 +71,7 @@ namespace ICU4N.Dev.Test.Collate
 
         public long Get(T obj)
         {
-            return !map.TryGetValue(obj, out RWLong count) ? 0 : count.value;
+            return !map.TryGetValue(obj, out RWInt64 count) ? 0 : count.value;
         }
 
         public Counter<T> Clear()
@@ -94,10 +94,10 @@ namespace ICU4N.Dev.Test.Collate
 
         private class Entry
         {
-            internal RWLong count;
+            internal RWInt64 count;
             internal T value;
             internal int uniqueness;
-            public Entry(RWLong count, T value, int uniqueness)
+            public Entry(RWInt64 count, T value, int uniqueness)
             {
                 this.count = count;
                 this.value = value;
@@ -178,7 +178,7 @@ namespace ICU4N.Dev.Test.Collate
             return GetEnumerator();
         }
 
-        public IDictionary<T, RWLong> GetMap()
+        public IDictionary<T, RWInt64> GetMap()
         {
             return map; // older code was protecting map, but not the integer values.
         }


### PR DESCRIPTION
Note that I did not rename Long and Integer types in ICU4N.Support, because renaming those to Int32/Int64 would clash with the built-in .NET types. But let me know if you think those need to be renamed too.

Fixes #12