### PR TITLE
Added net8.0 target and tests (Fixes #73)

### DIFF
--- a/.build/TestReferences.Common.targets
+++ b/.build/TestReferences.Common.targets
@@ -10,8 +10,8 @@
   </ItemGroup>
 
   <!-- See the following post to understand this approach: https://duanenewman.net/blog/post/a-better-way-to-override-references-with-packagereference/ -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <!-- On net452, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net47' ">
+    <!-- On net47, we incorrectly get references to System.Memory. We can exclude the DLL and dependencies as follows. The IDE view is wrong, these references don't actually exist.
         ExcludeAssets=compile removes the dependency from being referenced. ExcludeAssets=runtime removes the dependency from the build output. -->
 
     <PackageReference Include="J2N"

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -5,6 +5,7 @@
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
     <!--<TargetFramework>net47</TargetFramework>-->
+    <!--<TargetFramework>net472</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>netcoreapp2.0</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
@@ -22,18 +23,20 @@
       net8.0            | net8.0
       net6.0            | net6.0
       net5.0            | netstandard2.0
-      net48             | net451
+      net48             | net462
+      net472            | net451
       net47             | net40
 
     -->
     <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(VisualStudioVersion)' &gt;= '16.10'">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">$(TargetFrameworks);net5.0;net48;net47</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">$(TargetFrameworks);net5.0;net48;net472;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
 
   </PropertyGroup>
 
   <PropertyGroup Label="Mismatched Target Framework (to override the target framework under test)">
     <SetTargetFramework></SetTargetFramework>
+    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net472' ">TargetFramework=net451</SetTargetFramework>
     <SetTargetFramework Condition=" '$(TargetFramework)' == 'net47' ">TargetFramework=net40</SetTargetFramework>
   </PropertyGroup>
   

--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -4,28 +4,37 @@
     <!-- Changing this setting will allow testing on all target frameworks within Visual Studio 2017.
     Note that the main libraries are multi-targeted, so this has no effect on how they are compiled,
     this setting only affects the test projects. -->
-    <!--<TargetFramework>net452</TargetFramework>-->
+    <!--<TargetFramework>net47</TargetFramework>-->
     <!--<TargetFramework>net48</TargetFramework>-->
     <!--<TargetFramework>netcoreapp2.0</TargetFramework>-->
     <!--<TargetFramework>net5.0</TargetFramework>-->
     <!--<TargetFramework>net6.0</TargetFramework>-->
-    <!--<TargetFramework>net7.0</TargetFramework>-->
+    <!--<TargetFramework>net8.0</TargetFramework>-->
     <TestAllTargetFrameworks>true</TestAllTargetFrameworks>
 
     <!-- Allow the build script to pass in the test frameworks to build for.
       This overrides the above TargetFramework setting. 
       ICU4N TODO: Due to a parsing bug, we cannot pass a string with a ; to dotnet msbuild, so passing true as a workaround -->
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(VisualStudioVersion)' &gt;= '16.10'">net7.0;net6.0;</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">$(TargetFrameworks)net5.0;net48;net452</TargetFrameworks>
+
+    <!-- Test Client to DLL target works as follows:
+
+      Test Client       | Target Under Test
+      net8.0            | net8.0
+      net6.0            | net6.0
+      net5.0            | netstandard2.0
+      net48             | net451
+      net47             | net40
+
+    -->
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(VisualStudioVersion)' &gt;= '16.10'">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">$(TargetFrameworks);net5.0;net48;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
 
   </PropertyGroup>
 
   <PropertyGroup Label="Mismatched Target Framework (to override the target framework under test)">
     <SetTargetFramework></SetTargetFramework>
-    <SetTargetFramework Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">TargetFramework=netstandard2.1</SetTargetFramework>
-    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net452' ">TargetFramework=net40</SetTargetFramework>
-    <!--<SetTargetFramework Condition=" '$(TargetFramework)' == 'net461' ">TargetFramework=net45</SetTargetFramework>-->
+    <SetTargetFramework Condition=" '$(TargetFramework)' == 'net47' ">TargetFramework=net40</SetTargetFramework>
   </PropertyGroup>
   
 </Project>

--- a/.build/azure-templates/install-dotnet-sdk.yml
+++ b/.build/azure-templates/install-dotnet-sdk.yml
@@ -19,6 +19,7 @@
 
 parameters:
   sdkVersion: '' # The .NET SDK version to install
+  performMultiLevelLookup: 'false' # Whether to check for x86 when running commands
 
 steps:
 - pwsh: |
@@ -29,6 +30,7 @@ steps:
         }
     }
     EnsureNotNullOrEmpty('${{ parameters.sdkVersion }}', 'sdkVersion')
+    EnsureNotNullOrEmpty('${{ parameters.performMultiLevelLookup }}', 'performMultiLevelLookup')
   displayName: 'Validate Template Parameters'
 
 - bash: |
@@ -41,3 +43,4 @@ steps:
   inputs:
     packageType: 'sdk'
     version: '${{ parameters.sdkVersion }}'
+    performMultiLevelLookup: '${{ parameters.performMultiLevelLookup }}'

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -66,6 +66,16 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
+    framework: 'net472'
+    testProjectName: '${{ parameters.testProjectName }}'
+    osName: '${{ parameters.osName }}'
+    testPlatform: '${{ parameters.testPlatform }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
     framework: 'net47'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -26,7 +26,7 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
-    framework: 'net7.0'
+    framework: 'net8.0'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'
     testPlatform: '${{ parameters.testPlatform }}'
@@ -66,7 +66,7 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
-    framework: 'net452'
+    framework: 'net47'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'
     testPlatform: '${{ parameters.testPlatform }}'

--- a/.build/azure-templates/publish-test-results.yml
+++ b/.build/azure-templates/publish-test-results.yml
@@ -56,12 +56,20 @@ steps:
                     if ($reader.Name -eq 'RunInfos') {
                         $inRunInfos = $true
                     }
-                    if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text' -and $reader.ReadInnerXml().Contains('Test host process crashed')) {
-                        Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
-                        # Report all of the test projects that crashed
-                        $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
-                        Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
-                        $crashed = $true
+                    if ($inRunInfos -and !$crashed -and $reader.Name -eq 'Text') {
+                        $innerXml = $reader.ReadInnerXml()
+                        # Test for specific error messages - we may need to adjust this, as needed
+                        if ($innerXml -and ($innerXml.Contains('Test host process crashed') `
+                            -or $innerXml.Contains('Could not load file or assembly') `
+                            -or $innerXml.Contains("Could not find `'dotnet.exe`' host") `
+                            -or $innerXml.Contains('No test is available') `
+                            -or $innerXml.Contains('exited with error'))) {
+                            Write-Host "##vso[task.setvariable variable=HostCrashed;]true"
+                            # Report all of the test projects that crashed
+                            $crashedRuns = "$env:CRASHEDRUNS,$testProjectName".TrimStart(',')
+                            Write-Host "##vso[task.setvariable variable=CrashedRuns;]$crashedRuns"
+                            $crashed = $true
+                        }
                     }
                 }
                 if ($reader.NodeType -eq [System.Xml.XmlNodeType]::EndElement -and $reader.Name -eq 'RunInfos') {

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -159,6 +159,22 @@ steps:
         foreach ($testBinary in $testBinaries) {
             $testName = [System.IO.Path]::GetFileNameWithoutExtension($testBinary.FullName)
     
+            $testResultDirectory = "$testResultsArtifactDirectory/$testOSName/$framework/$testPlatform/$testName"
+            if (!(Test-Path "$testResultDirectory")) {
+                New-Item "$testResultDirectory" -ItemType Directory -Force
+            }
+
+            # Test binaries are copied to a temp directory so locking behavior of other processes doesn't interfere with this test run.
+            # We do this serially before entering the parallel job.
+            $tempTestDirectory = "$tempDirectory/$framework/$testName"
+            if (!(Test-Path "$tempTestDirectory")) {
+                New-Item "$tempTestDirectory" -ItemType Directory -Force
+            }
+            $testTarget = "$tempTestDirectory/$($testBinary.Name)"
+            $sourceDirectory = $testBinary.Directory.FullName
+
+            Copy-Item -Path "$sourceDirectory/*" -Destination "$tempTestDirectory" -Recurse -Force
+
             if ($maximumParalellJobs -gt 1) {
                 # Pause if we have queued too many parallel jobs
                 $running = @(Get-Job | Where-Object { $_.State -eq 'Running' })
@@ -169,21 +185,6 @@ steps:
                     $running | Wait-Job -Any | Out-Null
                 }
             }
-            
-            $testResultDirectory = "$testResultsArtifactDirectory/$testOSName/$framework/$testPlatform/$testName"
-            if (!(Test-Path "$testResultDirectory")) {
-                New-Item "$testResultDirectory" -ItemType Directory -Force
-            }
-
-            # Test binaries are copied to a temp directory so locking behavior of other processes doesn't interfere with this test run
-            $tempTestDirectory = "$tempDirectory/$framework/$testName"
-            if (!(Test-Path "$tempTestDirectory")) {
-                New-Item "$tempTestDirectory" -ItemType Directory -Force
-            }
-            $testTarget = "$tempTestDirectory/$($testBinary.Name)"
-            $sourceDirectory = $testBinary.Directory.FullName
-
-            Copy-Item -Path "$sourceDirectory/*" -Destination "$tempTestDirectory" -Recurse -Force
 
             $testExpression = "dotnet test ""$testTarget"" --framework ""$framework"" --blame --no-build --no-restore" + `
                 " --logger:""console;verbosity=normal"" --logger:""trx;LogFileName=$testResultsFileName""" + `

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -33,21 +33,95 @@ steps:
     EnsureNotNullOrEmpty('${{ parameters.dotNetSdkVersion }}', 'dotNetSdkVersion')
   displayName: 'Validate Template Parameters'
 
+- pwsh: |
+    $testTargetFrameworks = '${{ parameters.testTargetFrameworks }}'
+    $testPlatform = '${{ parameters.vsTestPlatform }}'
+    $dotnetSdkVersion = '${{ parameters.dotNetSdkVersion }}'
+    if ($IsWindows -eq $null) {
+        $IsWindows = $env:OS.StartsWith('Win')
+    }
+    # .NET Framework tests are SLOW when using the .NET 8 SDK (especially those for net47 targeting net40).
+    # So, we use .NET 6 SDK instead.
+    if ($testTargetFrameworks.StartsWith('net4')) {
+        $dotnetSdkVersion = '6.0.421'
+    }
+    Write-Host "Using SDK Version: $dotnetSdkVersion"
+    $performMulitLevelLookup = if ($IsWindows -and $testPlatform.Equals('x86')) { 'true' } else { 'false' }
+    Write-Host "##vso[task.setvariable variable=PerformMultiLevelLookup;]$performMulitLevelLookup"
+    Write-Host "##vso[task.setvariable variable=DotNetSdkVersion;]$dotnetSdkVersion"
+#- template: 'show-all-environment-variables.yml' # Uncomment for debugging
+
 - template: 'install-dotnet-sdk.yml'
   parameters:
-    sdkVersion: '${{ parameters.dotNetSdkVersion }}'
+    sdkVersion: '$(DotNetSdkVersion)'
+    performMultiLevelLookup: '$(PerformMultiLevelLookup)'
+
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '$(DotNetSdkVersion)'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK $(DotNetSdkVersion) (x86)'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net8.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: UseDotNet@2
-  displayName: 'Use .NET sdk 5.0.408'
+  displayName: 'Use .NET SDK 6.0.421'
   inputs:
-    version: 5.0.408
+    packageType: 'sdk'
+    version: '6.0.421'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net6.'))
+
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '6.0.421'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK 6.0.421 (x86)'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net6.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 5.0.408'
+  inputs:
+    packageType: 'sdk'
+    version: '5.0.408'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
   condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net5.'))
 
-- task: UseDotNet@2
-  displayName: 'Use .NET sdk 6.0.406'
-  inputs:
-    version: 6.0.406
-  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net6.'))
+    # Hack: .NET 8 no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '5.0.408'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK 5.0.408 (x86)'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net5.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 - task: DownloadPipelineArtifact@2
   displayName: 'Download Pipeline Artifacts: ${{ parameters.binaryArtifactName }}'

--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -3,17 +3,17 @@
     <IKVMMavenSdkPackageReferenceVersion>1.2.0</IKVMMavenSdkPackageReferenceVersion>
     <J2NPackageReferenceVersion>2.1.0-alpha-0090</J2NPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion>2.0.0</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
-    <MicrosoftExtensionsCachingMemoryPackageReferenceVersion Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">6.0.0</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
+    <MicrosoftExtensionsCachingMemoryPackageReferenceVersion Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">6.0.0</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion Condition=" '$(TargetFramework)' == 'net451' ">1.1.2</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>1.0.2</MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>
-    <MicrosoftNETTestSdkPackageReferenceVersion>16.1.1</MicrosoftNETTestSdkPackageReferenceVersion>
+    <MicrosoftNETTestSdkPackageReferenceVersion>17.11.0</MicrosoftNETTestSdkPackageReferenceVersion>
     <MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>1.1.1</MicrosoftSourceLinkAzureReposGitPackageReferenceVersion>
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
     <NetFxSystemMemoryPackageReferenceVersion>4.0.0</NetFxSystemMemoryPackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.12.0</NUnitPackageReferenceVersion>
-    <NUnit3TestAdapterPackageReferenceVersion>3.13.0</NUnit3TestAdapterPackageReferenceVersion>
+    <NUnit3TestAdapterPackageReferenceVersion>4.6.0</NUnit3TestAdapterPackageReferenceVersion>
     <SystemBuffersPackageReferenceVersion>4.5.1</SystemBuffersPackageReferenceVersion>
     <SystemMemoryPackageReferenceVersion>4.5.5</SystemMemoryPackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -17,7 +17,7 @@ properties {
     [string]$configuration         = "Release"
     [string]$platform              = "Any CPU"
     [bool]$backupFiles             = $true
-    [string]$minimumSdkVersion     = "6.0.100"
+    [string]$minimumSdkVersion     = "8.0.100"
 
     #test parameters
     [string]$testPlatforms         = "x64"

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <!--Features in .NET 7+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_IDICTIONARY_ASREADONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ILIST_ASREADONLY</DefineConstants>
@@ -21,21 +21,21 @@
   </PropertyGroup>
   
   <!--Features in .NET 6+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_SPANFORMATTABLE</DefineConstants>
 
   </PropertyGroup>
   
   <!--Features in .NET 5+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_HALF</DefineConstants>
 
   </PropertyGroup>
 
-  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 7.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_COMPARISONTYPE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_TRIM_SPAN_MEMORY_READONLYMEMORY</DefineConstants>
@@ -46,7 +46,7 @@
   </PropertyGroup>
 
   <!--Features in .NET Standard 2.x or .NET Core-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
@@ -62,8 +62,8 @@
 
 
 
-  <!-- Features in .NET Standard 2.1, .NET Core 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 7.x -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or ($(TargetFramework.StartsWith('netcoreapp2.')) And '$(TargetFramework)' != 'netcoreapp2.0') Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <!-- Features in .NET Standard 2.1, .NET Core 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or ($(TargetFramework.StartsWith('netcoreapp2.')) And '$(TargetFramework)' != 'netcoreapp2.0') Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_TOBYTEARRAY_BIGENDIAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
@@ -81,9 +81,9 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 7.x -->
-  <!-- These features are not in .NET Framework 4.0 or .NET Framework 4.5.2 (the target framework we use for testing .NET Framework 4.0) -->
-  <PropertyGroup Condition=" ('$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net452' And $(TargetFramework.StartsWith('net4'))) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x -->
+  <!-- These features are not in .NET Framework 4.0 or .NET Framework 4.7 (the target framework we use for testing .NET Framework 4.0) -->
+  <PropertyGroup Condition=" ('$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net47' And $(TargetFramework.StartsWith('net4'))) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTION_HRESULT</DefineConstants>
@@ -99,8 +99,8 @@
     
   </PropertyGroup>
 
-    <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, and .NET 7.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) ">
+    <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, and .NET 8.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_GETCULTURES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_IETFLANGUAGETAG</DefineConstants>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net8.0;net6.0;net5.0;net48;net47'
+  value: 'net8.0;net6.0;net5.0;net48;net472;net47'
 - name: DotNetSDKVersion
   value: '8.0.401'
 - name: BinaryArtifactName
@@ -288,6 +288,36 @@ stages:
       parameters:
         osName: 'Windows'
         testTargetFrameworks: 'net48'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net472_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    displayName: 'Test net472,x64 on Windows'
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: 'Windows'
+        testTargetFrameworks: 'net472'
+        vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net472_x86 # Only run if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
+    displayName: 'Test net472,x86 on Windows'
+    pool:
+      vmImage: 'windows-2019'
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: 'Windows'
+        testTargetFrameworks: 'net472'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,9 +23,9 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net7.0;net6.0;net5.0;netcoreapp3.1;net48;net452'
+  value: 'net8.0;net6.0;net5.0;net48;net47'
 - name: DotNetSDKVersion
-  value: '7.0.201'
+  value: '8.0.401'
 - name: BinaryArtifactName
   value: 'testbinaries'
 - name: NuGetArtifactName
@@ -113,7 +113,7 @@ stages:
   displayName: 'Test Stage:'
   jobs:
 
-  - job: Test_net7_0_x64
+  - job: Test_net8_0_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
     strategy:
       matrix:
@@ -129,20 +129,20 @@ stages:
           osName: 'macOS'
           imageName: 'macOS-latest'
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net7.0,x64 on'
+    displayName: 'Test net8.0,x64 on'
     pool:
       vmImage: $(imageName)
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: $(osName)
-        testTargetFrameworks: 'net7.0'
+        testTargetFrameworks: 'net8.0'
         vsTestPlatform: 'x64'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: $(maximumAllowedFailures)
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net7_0_x86 # Only run if explicitly enabled with RunX86Tests
+  - job: Test_net8_0_x86 # Only run if explicitly enabled with RunX86Tests
     condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
     strategy:
       matrix:
@@ -150,14 +150,14 @@ stages:
           osName: 'Windows'
           imageName: 'windows-2019'
           maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
-    displayName: 'Test net7.0,x86 on'
+    displayName: 'Test net8.0,x86 on'
     pool:
       vmImage: $(imageName)
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: $(osName)
-        testTargetFrameworks: 'net7.0'
+        testTargetFrameworks: 'net8.0'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: $(maximumAllowedFailures)
@@ -293,31 +293,31 @@ stages:
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net452_x64
+  - job: Test_net47_x64
     condition: and(succeeded(), ne(variables['RunTests'], 'false'))
-    displayName: 'Test net452,x64 on Windows'
+    displayName: 'Test net47,x64 on Windows'
     pool:
       vmImage: 'windows-2019'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net452'
+        testTargetFrameworks: 'net47'
         vsTestPlatform: 'x64'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
-  - job: Test_net452_x86 # Only run if explicitly enabled with RunX86Tests
+  - job: Test_net47_x86 # Only run if explicitly enabled with RunX86Tests
     condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
-    displayName: 'Test net452,x86 on Windows'
+    displayName: 'Test net47,x86 on Windows'
     pool:
       vmImage: 'windows-2019'
     steps:
     - template: '.build/azure-templates/run-tests-on-os.yml'
       parameters:
         osName: 'Windows'
-        testTargetFrameworks: 'net452'
+        testTargetFrameworks: 'net47'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -335,6 +335,7 @@ stages:
         testTargetFrameworks: 'net47'
         vsTestPlatform: 'x64'
         testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumParallelJobs: 1 # Don't run tests in parallel because of file locking issues with satellite assemblies
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 
@@ -350,6 +351,7 @@ stages:
         testTargetFrameworks: 'net47'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumParallelJobs: 1 # Don't run tests in parallel because of file locking issues with satellite assemblies
         maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
         dotNetSdkVersion: '$(DotNetSDKVersion)'
 

--- a/docs/building-and-testing.md
+++ b/docs/building-and-testing.md
@@ -5,7 +5,7 @@
 ### Prerequisites
 
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 3.0 or higher (see [this question](http://stackoverflow.com/questions/1825585/determine-installed-powershell-version) to check your PowerShell version)
-- [.NET 7.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/7.0)
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 - [.NET Framework 4.6.2 Developer Pack or Higher](https://dotnet.microsoft.com/en-us/download/dotnet-framework)
 
 ### Execution
@@ -88,7 +88,7 @@ Then all you need to do is choose the `ICU4N Local Packages` feed from the dropd
 ### Prerequisites
 
 1. Visual Studio 2019 or higher
-2. [.NET 7.0 SDK or higher](https://dotnet.microsoft.com/download/visual-studio-sdks)
+2. [.NET 8.0 SDK or higher](https://dotnet.microsoft.com/download/visual-studio-sdks)
 
 > **NOTE:** Preview versions of .NET SDK require the "Use previews of the .NET SDK (requires restart)" option to be enabled in Visual Studio under Tools > Options > Environment > Preview Features. .NET 6.0 is not supported on Visual Studio 2019, so the only option available for building on VS 2019 is to use a pre-release .NET 6.0 SDK.
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -4,7 +4,7 @@ This project uses Nerdbank.GitVersioning to assist with creating version numbers
 
 ## Prerequisites
 
-- [.NET 6 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/6.0)
+- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
 - [nbgv tool](https://www.nuget.org/packages/nbgv/) (the version must match the one used in the [dependencies.props](.build/dependencies.props) file)
 
 ### Installing NBGV Tool

--- a/src/ICU4N.Collation/ICU4N.Collation.csproj
+++ b/src/ICU4N.Collation/ICU4N.Collation.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.Collation/ICU4N.Collation.csproj
+++ b/src/ICU4N.Collation/ICU4N.Collation.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
+++ b/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
+++ b/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
+++ b/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
+++ b/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.RegionData/ICU4N.RegionData.csproj
+++ b/src/ICU4N.RegionData/ICU4N.RegionData.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.RegionData/ICU4N.RegionData.csproj
+++ b/src/ICU4N.RegionData/ICU4N.RegionData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.Resources.NETFramework4.0/Properties/AssemblyInfo.cs
+++ b/src/ICU4N.Resources.NETFramework4.0/Properties/AssemblyInfo.cs
@@ -1,0 +1,17 @@
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM.
+
+[assembly: Guid("59e6dc20-2c3c-431c-983c-c0f1656bc18a")]

--- a/src/ICU4N.Resources/Properties/AssemblyInfo.cs
+++ b/src/ICU4N.Resources/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+using System.Runtime.InteropServices;
+
+// In SDK-style projects such as this one, several assembly attributes that were historically
+// defined in this file are now automatically added during build and populated with
+// values defined in project properties. For details of which attributes are included
+// and how to customise this process see: https://aka.ms/assembly-info-properties
+
+
+// Setting ComVisible to false makes the types in this assembly not visible to COM
+// components.  If you need to access a type in this assembly from COM, set the ComVisible
+// attribute to true on that type.
+
+[assembly: ComVisible(false)]

--- a/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
+++ b/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework></TargetFramework>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>

--- a/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
+++ b/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>net7.0;net6.0;netstandard2.0;net451;net40</TargetFrameworks>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net7.0;net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>

--- a/src/ICU4N.TestFramework/Support/Utf32Regex.cs
+++ b/src/ICU4N.TestFramework/Support/Utf32Regex.cs
@@ -59,10 +59,12 @@ namespace ICU4N.Support
         }
 
 #if FEATURE_SERIALIZABLE
+#pragma warning disable SYSLIB0051 // .ctor(SerializationInfo, StreamingContext) is obsolete
         protected Utf32Regex(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
             : base(serializationInfo, streamingContext)
         {
         }
+#pragma warning restore SYSLIB0051 // .ctor(SerializationInfo, StreamingContext) is obsolete
 #endif
 
         private static string ConvertUTF32Characters(string regexString)

--- a/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
+++ b/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
+++ b/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N/ICU4N.csproj
+++ b/src/ICU4N/ICU4N.csproj
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     
@@ -48,6 +48,11 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageReferenceVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageReferenceVersion)" />
     <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>

--- a/src/ICU4N/ICU4N.csproj
+++ b/src/ICU4N/ICU4N.csproj
@@ -4,10 +4,8 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net7.0;net6.0;</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks)netstandard2.0;net451;net40</TargetFrameworks>
-    
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard1.3' ">$(DefineConstants);LIBLOG_PORTABLE</DefineConstants>
+    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net8.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net451;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     
@@ -41,7 +39,7 @@
     <PackageReference Include="J2N" Version="$(J2NPackageReferenceVersion)" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
@@ -70,7 +68,7 @@
   <PropertyGroup>
     <ICU4JResourceConverterDir>$(SolutionDir)src/tools/ICU4JResourceConverter</ICU4JResourceConverterDir>
     <ICU4JResourceConverterTargetFramework>net5.0</ICU4JResourceConverterTargetFramework>
-    <ICU4JResourceConverterTargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net7.0</ICU4JResourceConverterTargetFramework>
+    <ICU4JResourceConverterTargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net8.0</ICU4JResourceConverterTargetFramework>
     <ICU4JResourceConverterOutputDir>$(ICU4JResourceConverterDir)/bin/$(Configuration)/$(ICU4JResourceConverterTargetFramework)</ICU4JResourceConverterOutputDir>
 
     <ICU4JDownloadConfigFilePath>$(SolutionDir).build/icu4j-download-urls.txt</ICU4JDownloadConfigFilePath>

--- a/src/ICU4N/Support/Compatibility/NullableAttributes.cs
+++ b/src/ICU4N/Support/Compatibility/NullableAttributes.cs
@@ -2,7 +2,7 @@
 #pragma warning disable MA0048 // File name must match type name
 #pragma warning restore IDE0079 // Remove unnecessary suppression
 #define INTERNAL_NULLABLE_ATTRIBUTES
-#if NETSTANDARD1_3 || NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NET40 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#if NETSTANDARD1_3 || NETSTANDARD2_0 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NET40 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48 || NET481
 
 // https://github.com/dotnet/corefx/blob/48363ac826ccf66fbe31a5dcb1dc2aab9a7dd768/src/Common/src/CoreLib/System/Diagnostics/CodeAnalysis/NullableAttributes.cs
 
@@ -141,7 +141,7 @@ namespace System.Diagnostics.CodeAnalysis
 }
 #endif
 // These didn't exist before .NET 5.0
-#if NETSTANDARD1_3 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET40 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48
+#if NETSTANDARD1_3 || NETSTANDARD2_0 || NETSTANDARD2_1 || NETCOREAPP2_0 || NETCOREAPP2_1 || NETCOREAPP2_2 || NETCOREAPP3_0 || NETCOREAPP3_1 || NET40 || NET45 || NET451 || NET452 || NET6 || NET461 || NET462 || NET47 || NET471 || NET472 || NET48 || NET481
 namespace System.Diagnostics.CodeAnalysis
 {
     [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, AllowMultiple = true, Inherited = false)]

--- a/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
+++ b/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
-    <TargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net7.0</TargetFramework>
+    <TargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net8.0</TargetFramework>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -1,4 +1,79 @@
-<Project>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   <Import Project="$(SolutionDir)/.build/TestReferences.Common.targets" />
+
+  <UsingTask TaskName="UpdateRuntimeConfigProperty" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <RuntimeConfigFile ParameterType="System.String" Required="true" />
+      <PropertyName ParameterType="System.String" Required="true" />
+      <PropertyValue ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        if (File.Exists(RuntimeConfigFile))
+        {
+            // Read the file content
+            string jsonContent = File.ReadAllText(RuntimeConfigFile);
+
+            // Ensure runtimeOptions and configProperties sections exist
+            if (!jsonContent.Contains("\"runtimeOptions\""))
+            {
+                jsonContent = jsonContent.TrimEnd('}', '\n', '\r') + ",\n  \"runtimeOptions\": {\n    \"configProperties\": {\n    }\n  }\n}";
+            }
+            if (!jsonContent.Contains("\"configProperties\""))
+            {
+                int runtimeOptionsIndex = jsonContent.IndexOf("\"runtimeOptions\"");
+                int insertPosition = jsonContent.IndexOf('}', runtimeOptionsIndex);
+                jsonContent = jsonContent.Insert(insertPosition, ",\n    \"configProperties\": {\n    }\n");
+            }
+
+            // Check if the property already exists
+            int configPropertiesIndex = jsonContent.IndexOf("\"configProperties\"");
+            int propertyIndex = jsonContent.IndexOf("\"" + PropertyName + "\"", configPropertiesIndex);
+
+            if (propertyIndex != -1)
+            {
+                // Property exists, update its value
+                int valueStartIndex = jsonContent.IndexOf(':', propertyIndex) + 1;
+                int valueEndIndex = jsonContent.IndexOfAny(new char[] { ',', '}', '\n' }, valueStartIndex);
+                jsonContent = jsonContent.Remove(valueStartIndex, valueEndIndex - valueStartIndex)
+                                         .Insert(valueStartIndex, " " + PropertyValue);
+            }
+            else
+            {
+                // Property does not exist, add it
+                int closingBraceIndex = jsonContent.IndexOf('}', configPropertiesIndex);
+                jsonContent = jsonContent.Insert(closingBraceIndex, "  \"" + PropertyName + "\": " + PropertyValue + ",\n");
+            }
+
+            // Write the updated content back to the file
+            File.WriteAllText(RuntimeConfigFile, jsonContent);
+        }
+        else
+        {
+            Log.LogError("File not found: " + RuntimeConfigFile);
+        }
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <!-- Target to invoke the task after build -->
+  <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
+    <PropertyGroup>
+      <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
+      <DotNet_8_0_OrGreater>false</DotNet_8_0_OrGreater>
+      <DotNet_8_0_OrGreater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ($(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or ($(TargetFramework.StartsWith('net')) And $(TargetFramework.IndexOf('.')) > 4))">true</DotNet_8_0_OrGreater>
+    </PropertyGroup>
+
+    <UpdateRuntimeConfigProperty
+        RuntimeConfigFile="$(RuntimeConfigFile)"
+        PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"
+        PropertyValue="true"
+        Condition="Exists('$(RuntimeConfigFile)') And '$(DotNet_8_0_OrGreater)' == 'true'" />
+  </Target>
+  
 </Project>

--- a/tests/ICU4N.Tests/ICU4N.Tests.csproj
+++ b/tests/ICU4N.Tests/ICU4N.Tests.csproj
@@ -18,7 +18,7 @@
     <NoWarn>$(NoWarn);1701;1702</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' != 'net452' And '$(DisableIkvm)' != 'true' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' != 'net47' And '$(DisableIkvm)' != 'true' ">
     <DefineConstants>$(DefineConstants);FEATURE_IKVM</DefineConstants>
   </PropertyGroup>
 
@@ -63,7 +63,7 @@
     </ProjectReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net452' And '$(DisableIkvm)' != 'true' ">
+  <ItemGroup Condition=" '$(TargetFramework)' != 'net47' And '$(DisableIkvm)' != 'true' ">
     <PackageReference Include="IKVM.Maven.Sdk" Version="$(IKVMMavenSdkPackageReferenceVersion)" />
     <MavenReference Include="com.ibm.icu:icu4j" Version="$(ICU4JMavenPackageReferenceVersion)" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #73 

This adds .NET 8 support and tests. It also adds a `net462` target which aligns with J2N and Lucene.NET.

A lot of the CI bits were brought over from J2N, so the process went pretty smoothly by comparison.