### PR TITLE
ICU4N.Resources.csproj: Removed NETStandard.Library as a transitive dependency

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -11,6 +11,7 @@
     <MicrosoftSourceLinkGitHubPackageReferenceVersion>$(MicrosoftSourceLinkAzureReposGitPackageReferenceVersion)</MicrosoftSourceLinkGitHubPackageReferenceVersion>
     <NerdBankGitVersioningPackageReferenceVersion>[3.5.73-alpha]</NerdBankGitVersioningPackageReferenceVersion>
     <NetFxSystemMemoryPackageReferenceVersion>4.0.0</NetFxSystemMemoryPackageReferenceVersion>
+    <NETStandardLibrary10PackageReferenceVersion>1.6.1</NETStandardLibrary10PackageReferenceVersion>
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.12.0</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>4.6.0</NUnit3TestAdapterPackageReferenceVersion>

--- a/src/ICU4N.Resources/ICU4N.Resources.csproj
+++ b/src/ICU4N.Resources/ICU4N.Resources.csproj
@@ -14,4 +14,9 @@
     <None Include="$(ICU4NSatelliteAssemblyOutputDir)/**/*.resources.dll" Pack="true" PackagePath="lib/netstandard1.0" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Reference NETStandard.Library for .NET Standard 1.0, but avoid including it as a transitive dependency -->
+    <PackageReference Update="NETStandard.Library" Version="$(NETStandardLibrary10PackageReferenceVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Removed [NETStandard.Library](https://www.nuget.org/packages/NETStandard.Library/) as a transitive dependency so users aren't required to install this metapackage (fixes #67). These are not required by our satellite assemblies and version 1.6.1 installs DLLs that are out of date.