### PR TITLE
ICU4N.Resources: Include Newtonsoft.Json binaries so we don't conflict with consumers

### DIFF
--- a/ICU4N.sln
+++ b/ICU4N.sln
@@ -56,6 +56,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{543196C0-5AE
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
 		src\Directory.Build.targets = src\Directory.Build.targets
+		src\ICU4N.Resources.PackJsonSerializer.targets = src\ICU4N.Resources.PackJsonSerializer.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{8C266EC1-9565-4827-B3AD-AC657F6BDC27}"

--- a/src/ICU4N.Resources.CopyPatch.targets
+++ b/src/ICU4N.Resources.CopyPatch.targets
@@ -6,6 +6,13 @@
     because there are many .NET SDKs that are broken in this way. If you customize the resources for your build, be sure to include this patch
     so locales with 3-letter language codes will be distributed with your application or consumers of your application on NuGet.
     
+    To use this patch, the project you are packing must import the ICU4N.Resources.PackJsonSerializer.targets file.
+    
+    <Import Project="ICU4N.Resources.PackJsonSerializer.targets"/>
+    
+    This file will copy the appropriate Newtonsoft.Json.dll file into your NuGet package along with its (MIT) license file. It is only used to
+    update the .deps.json file after copying any missing ICU4N.resources.dll files into the output directory to ensure the build output is consistent.
+    
     Required properties to be defined before importing:
     
     _ICU4NResourcesPackageId -                Package Id of the current NuGet project (the one containing the satellite assemblies to be copied)
@@ -26,14 +33,6 @@
     <_ICU4NTargetDepsJsonFileName>$(AssemblyName).deps.json</_ICU4NTargetDepsJsonFileName>
   </PropertyGroup>
 
-  <PropertyGroup Label="Newtonsoft.Json properties">
-    <_ICU4NNewtonsoftJsonPackageVersion Condition="'$(_ICU4NNewtonsoftJsonPackageVersion)' == ''">13.0.3</_ICU4NNewtonsoftJsonPackageVersion>
-  </PropertyGroup>
-
-  <ItemGroup Condition=" '$(PkgNewtonsoft_Json)' == '' ">
-    <PackageReference Include="Newtonsoft.Json" Version="$(_ICU4NNewtonsoftJsonPackageVersion)" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup>
     <_ICU4NResourceFiles Include="$(_ICU4NResourcesDirectory)/**/*.resources.dll" Exclude="$(_ICU4NResourcesDirectory)/ICU4N.resources.dll" />
   </ItemGroup>
@@ -53,7 +52,7 @@
       <SatelliteResourceLanguages ParameterType="System.String" Required="false" />
     </ParameterGroup>
     <Task>
-      <Reference Include="$(NugetPackageRoot)/newtonsoft.json/$(_ICU4NNewtonsoftJsonPackageVersion)/lib/$(_ICU4NNewtonsoftJsonTargetFramework)/Newtonsoft.Json.dll" />
+      <Reference Include="$(_ICU4NResourcesPackageRootDirectory)/buildTransitive/newtonsoft.json/$(_ICU4NNewtonsoftJsonTargetFramework)/Newtonsoft.Json.dll" />
       <Using Namespace="System" />
       <Using Namespace="System.Collections.Generic" />
       <Using Namespace="System.IO" />

--- a/src/ICU4N.Resources.NETFramework4.0/ICU4N.Resources.NETFramework4.0.csproj
+++ b/src/ICU4N.Resources.NETFramework4.0/ICU4N.Resources.NETFramework4.0.csproj
@@ -18,4 +18,10 @@
     <None Include="../ICU4N.Resources.CopyPatch.targets" Pack="true" PackagePath="buildTransitive/ICU4N.Resources.CopyPatch.targets" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <_ICU4NNewtonsoftJsonTargetFramework>$(TargetFramework)</_ICU4NNewtonsoftJsonTargetFramework>
+  </PropertyGroup>
+
+  <Import Project="../ICU4N.Resources.PackJsonSerializer.targets" Condition="'$(PackResourceStubs)' != 'true'" />
+  
 </Project>

--- a/src/ICU4N.Resources.PackJsonSerializer.targets
+++ b/src/ICU4N.Resources.PackJsonSerializer.targets
@@ -1,0 +1,65 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- 
+    ===========================================================================================================================================================
+    
+    This will:
+    
+    1. Restore Newtonsoft.Json from NuGet.
+    2. When you pack your project, it will automatically include the Newtonsoft.Json.dll file in your package along with its (MIT) license file.
+    3. NOT include the PackageReference to Newtonsoft.Json with your package, not even as a private asset. This ensures we won't have any transitive
+       dependency conflicts with Newtonsoft.Json, but does make the package size a bit larger.
+    
+    The DLL is put in a known location so the ICU4N.Resources.CopyPatch.targets file can utilize it for updating the .deps.json file in the build
+    or publish output.
+    
+    It supports the following optional properties to be defined before importing:
+    
+    _ICU4NNewtonsoftJsonPackageVersion -      The NuGet package version of Newtonsoft.Json to include.
+    
+    _ICU4NNewtonsoftJsonTargetFramework -     The target framework of Newtonsoft.Json to use from the version specified in _ICU4NNewtonsoftJsonPackageVersion.
+                                              Note that ICU4N.Resources.CopyPatch.targets does not support dependencies, so it is important to select a target
+                                              framework of Newtonsoft.Json that has no dependencies defined or provide them in your build.
+    ===========================================================================================================================================================
+  -->
+  
+  <PropertyGroup Label="Newtonsoft.Json properties">
+    <_ICU4NNewtonsoftJsonTargetFramework Condition="'$(_ICU4NNewtonsoftJsonTargetFramework)' == ''">netstandard2.0</_ICU4NNewtonsoftJsonTargetFramework>
+    <!-- NOTE: We don't want to risk this package getting a dependency in the future, so we pin it to a specific version here. -->
+    <_ICU4NNewtonsoftJsonPackageVersion Condition="'$(_ICU4NNewtonsoftJsonPackageVersion)' == ''">13.0.3</_ICU4NNewtonsoftJsonPackageVersion>
+  
+    <NoWarn Label="The assembly is not inside of the 'lib' folder and hence it won't be addd as a reference when the package is installed in the project.">$(NoWarn);NU5100</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(NugetPackageRoot)/newtonsoft.json/$(_ICU4NNewtonsoftJsonPackageVersion)/lib/$(_ICU4NNewtonsoftJsonTargetFramework)/Newtonsoft.Json.dll">
+      <Pack>true</Pack>
+      <PackagePath>buildTransitive/newtonsoft.json/$(_ICU4NNewtonsoftJsonTargetFramework)/Newtonsoft.Json.dll</PackagePath>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(NugetPackageRoot)/newtonsoft.json/$(_ICU4NNewtonsoftJsonPackageVersion)/LICENSE.md">
+      <Pack>true</Pack>
+      <PackagePath>buildTransitive/newtonsoft.json/$(_ICU4NNewtonsoftJsonTargetFramework)/LICENSE.md</PackagePath>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPackaging)' != 'true' And '$(PkgNewtonsoft_Json)' == ''">
+    <PackageReference Include="Newtonsoft.Json" Version="$(_ICU4NNewtonsoftJsonPackageVersion)" PrivateAssets="All" />
+  </ItemGroup>
+
+  <Target Name="BeforePacking" BeforeTargets="Pack">
+    <PropertyGroup>
+      <IsPackaging>true</IsPackaging>
+    </PropertyGroup>
+    <Message Text="Packaging $(PackageId) without Newtonsoft.Json PackageReference..." Importance="high" />
+  </Target>
+
+  <Target Name="AfterPacking" AfterTargets="Pack">
+    <PropertyGroup>
+      <IsPackaging>false</IsPackaging>
+    </PropertyGroup>
+    <Message Text="Finished packaging $(PackageId)." Importance="high" />
+  </Target>
+
+</Project>

--- a/src/ICU4N.Resources/ICU4N.Resources.csproj
+++ b/src/ICU4N.Resources/ICU4N.Resources.csproj
@@ -22,4 +22,10 @@
     <PackageReference Update="NETStandard.Library" Version="$(NETStandardLibrary20PackageReferenceVersion)" PrivateAssets="All" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <_ICU4NNewtonsoftJsonTargetFramework>$(TargetFramework)</_ICU4NNewtonsoftJsonTargetFramework>
+  </PropertyGroup>
+
+  <Import Project="../ICU4N.Resources.PackJsonSerializer.targets" Condition="'$(PackResourceStubs)' != 'true'" />
+
 </Project>


### PR DESCRIPTION
ICU4N.Resources + ICU4N.Resources.NETFramework4.0: Added `ICU4N.Resources.PackJsonSerializer.targets` file to package Newtonsoft.Json.dll inside of our .nupkg files so we don't interfere with referencing Newtonsoft.Json in the consuming project or one of its transitive dependencies.

This will prevent any potential DLL hell issues that would happen for end users if we have a private dependency on Newtonsoft.Json.

Newtonsoft.Json is MIT licensed, and we are packing the license file with the DLL.