### PR TITLE
.build/dependencies.props: Added version constraint

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -1,7 +1,8 @@
 <Project>
   <PropertyGroup Label="NuGet Package Reference Versions">
     <IKVMMavenSdkPackageReferenceVersion>1.2.0</IKVMMavenSdkPackageReferenceVersion>
-    <J2NPackageReferenceVersion>2.1.0</J2NPackageReferenceVersion>
+    <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
+    <J2NPackageReferenceVersion>[2.1.0, 3.0.0)</J2NPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion>6.0.2</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion Condition=" '$(TargetFramework)' == 'net451' ">1.1.2</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>1.0.3</MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>


### PR DESCRIPTION
Added version constraint for J2N so it can not be upgraded to 3.0.0 or higher. J2N 3.0.0 will have breaking binary changes that will prevent it from being used as a drop-in replacement in some APIs that ICU4N uses.