### PR TITLE
BugFix: ICU4N.Text (Normalizer + Normalizer2): Fixed access to unpinned pointers

### DIFF
--- a/src/ICU4N/Impl/Norm2AllModes.cs
+++ b/src/ICU4N/Impl/Norm2AllModes.cs
@@ -23,7 +23,7 @@ namespace ICU4N.Impl
             return dest.Append(src);
         }
 
-        internal override void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest)
+        internal override void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest)
         {
             if (src.Overlaps(dest.RawChars))
             {
@@ -59,7 +59,7 @@ namespace ICU4N.Impl
             return first.Append(second);
         }
 
-        internal override void NormalizeSecondAndAppend(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+        internal override void NormalizeSecondAndAppend(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             if (first.RawChars.Overlaps(second))
             {
@@ -81,7 +81,7 @@ namespace ICU4N.Impl
             return first.Append(second);
         }
 
-        internal override void Append(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+        internal override void Append(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             if (first.RawChars.Overlaps(second))
             {
@@ -295,7 +295,7 @@ namespace ICU4N.Impl
             return dest;
         }
 
-        internal override void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest)
+        internal override void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest)
         {
             if (src.Overlaps(dest.RawChars))
             {
@@ -311,10 +311,7 @@ namespace ICU4N.Impl
             {
                 Normalize(src, ref buffer);
                 dest.Length = 0;
-                unsafe
-                {
-                    dest.Append(new ReadOnlySpan<char>(buffer.GetCharsPointer(), buffer.Length));
-                }
+                dest.Append(buffer.AsSpan());
             }
             finally
             {
@@ -362,7 +359,7 @@ namespace ICU4N.Impl
             return NormalizeSecondAndAppend(first, second, doNormalize: true);
         }
 
-        internal override void NormalizeSecondAndAppend(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+        internal override void NormalizeSecondAndAppend(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             NormalizeSecondAndAppend(ref first, second, doNormalize: true);
         }
@@ -376,7 +373,7 @@ namespace ICU4N.Impl
             return NormalizeSecondAndAppend(first, second, false);
         }
 
-        internal override void Append(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+        internal override void Append(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             NormalizeSecondAndAppend(ref first, second, false);
         }
@@ -409,7 +406,7 @@ namespace ICU4N.Impl
             return first;
         }
 
-        internal virtual void NormalizeSecondAndAppend(ref ValueStringBuilder first, ReadOnlySpan<char> second, bool doNormalize)
+        internal virtual void NormalizeSecondAndAppend(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second, bool doNormalize)
         {
             if (first.RawChars.Overlaps(second))
             {
@@ -426,10 +423,7 @@ namespace ICU4N.Impl
                 var buffer = new ReorderingBuffer(Impl, ref sb, length);
                 NormalizeAndAppend(second, doNormalize, ref buffer);
                 first.Length = 0;
-                unsafe
-                {
-                    first.Append(new ReadOnlySpan<char>(buffer.GetCharsPointer(), buffer.Length));
-                }
+                first.Append(buffer.AsSpan());
             }
             finally
             {

--- a/src/ICU4N/Impl/Normalizer2Impl.cs
+++ b/src/ICU4N/Impl/Normalizer2Impl.cs
@@ -458,9 +458,6 @@ namespace ICU4N.Impl
         public ReadOnlySpan<char> AsSpan(int start) => str.AsSpan(start);
         public ReadOnlySpan<char> AsSpan(int start, int length) => str.AsSpan(start, length);
 
-        [CLSCompliant(false)]
-        public char* GetCharsPointer() => str.GetCharsPointer();
-
         public Span<char> RawChars => str.RawChars;
 
         public bool TryCopyTo(Span<char> destination, out int charsWritten) => str.TryCopyTo(destination, out charsWritten);
@@ -474,7 +471,7 @@ namespace ICU4N.Impl
             return UTF16Plus.Equal(str.AsSpan(), s.AsSpan(start, length));
         }
 
-        public bool Equals(ReadOnlySpan<char> s)
+        public bool Equals(scoped ReadOnlySpan<char> s)
         {
             return UTF16Plus.Equal(str.AsSpan(), s);
         }
@@ -1633,7 +1630,7 @@ namespace ICU4N.Impl
         }
 
         // ICU4N TODO: Make public TryDecompose() method that accepts ReadOnlySpan<char>, Span<char>, out int charLength
-        internal void Decompose(ReadOnlySpan<char> s, ref ValueStringBuilder dest) // ICU4N: internal because ValueStringBuilder is internal
+        internal void Decompose(scoped ReadOnlySpan<char> s, scoped ref ValueStringBuilder dest) // ICU4N: internal because ValueStringBuilder is internal
         {
             Decompose(s, ref dest, s.Length);
         }
@@ -1665,7 +1662,7 @@ namespace ICU4N.Impl
         /// length can be NULL if src is NUL-terminated.
         /// <paramref name="destLengthEstimate"/> is the initial <paramref name="dest"/> buffer capacity and can be -1.
         /// </summary>
-        internal void Decompose(ReadOnlySpan<char> s, ref ValueStringBuilder dest, int destLengthEstimate)
+        internal void Decompose(scoped ReadOnlySpan<char> s, scoped ref ValueStringBuilder dest, int destLengthEstimate)
         {
             int src = 0, limit = s.Length;
             if (destLengthEstimate < 0)
@@ -1681,7 +1678,7 @@ namespace ICU4N.Impl
         // normalize
         // ICU4N: This was part of the dual functionality of Decompose() in ICU4J.
         // Separated out into Decompose() and DecomposeQuickCheck() so we can use a ref struct for the buffer.
-        public int Decompose(ReadOnlySpan<char> s, ref ReorderingBuffer buffer)
+        public int Decompose(scoped ReadOnlySpan<char> s, scoped ref ReorderingBuffer buffer)
         {
             int src = 0, limit = s.Length;
             int minNoCP = minDecompNoCP;
@@ -1841,7 +1838,7 @@ namespace ICU4N.Impl
             return src;
         }
 
-        public void DecomposeAndAppend(ReadOnlySpan<char> s, bool doDecompose, ref ReorderingBuffer buffer)
+        public void DecomposeAndAppend(scoped ReadOnlySpan<char> s, bool doDecompose, scoped ref ReorderingBuffer buffer)
         {
             int limit = s.Length;
             if (limit == 0)
@@ -1876,10 +1873,10 @@ namespace ICU4N.Impl
         // Very similar to ComposeQuickCheck(): Make the same changes in both places if relevant.
         // doCompose: normalize
         // !doCompose: isNormalized (buffer must be empty and initialized)
-        public bool Compose(ReadOnlySpan<char> s,
+        public bool Compose(scoped ReadOnlySpan<char> s,
                            bool onlyContiguous,
                            bool doCompose,
-                           ref ReorderingBuffer buffer)
+                           scoped ref ReorderingBuffer buffer)
         {
             int src = 0, limit = s.Length;
             int prevBoundary = src;
@@ -2335,10 +2332,10 @@ namespace ICU4N.Impl
             }
         }
 
-        public void ComposeAndAppend(ReadOnlySpan<char> s,
+        public void ComposeAndAppend(scoped ReadOnlySpan<char> s,
             bool doCompose,
             bool onlyContiguous,
-            ref ReorderingBuffer buffer)
+            scoped ref ReorderingBuffer buffer)
         {
             int src = 0, limit = s.Length;
             if (!buffer.IsEmpty)
@@ -2357,10 +2354,7 @@ namespace ICU4N.Impl
                         middle.Append(buffer.AsSpan(), lastStarterInDest, buffer.Length - lastStarterInDest); // ICU4N : Fixed 3rd parameter
                         buffer.RemoveSuffix(buffer.Length - lastStarterInDest);
                         middle.Append(s, 0, firstStarterInSrc - 0);
-                        unsafe
-                        {
-                            Compose(new ReadOnlySpan<char>(middle.GetCharsPointer(), middle.Length), onlyContiguous, true, ref buffer);
-                        }
+                        Compose(middle.AsSpan(), onlyContiguous, true, ref buffer);
                         src = firstStarterInSrc;
                     }
                     finally
@@ -2381,7 +2375,7 @@ namespace ICU4N.Impl
 
         // normalize
         // ICU4N: Separated dual functionality that was in ICU4J into MakeFCD() and MakeFCDSpanQuickCheckYes()
-        public int MakeFCD(ReadOnlySpan<char> s, ref ReorderingBuffer buffer)
+        public int MakeFCD(scoped ReadOnlySpan<char> s, scoped ref ReorderingBuffer buffer)
         {
             // Note: In this function we use buffer->appendZeroCC() because we track
             // the lead and trail combining classes here, rather than leaving it to
@@ -2704,10 +2698,7 @@ namespace ICU4N.Impl
                         middle.Append(buffer.AsSpan(), lastBoundaryInDest, buffer.Length - lastBoundaryInDest); // ICU4N : Fixed 3rd parameter
                         buffer.RemoveSuffix(buffer.Length - lastBoundaryInDest);
                         middle.Append(s, 0, firstBoundaryInSrc - 0);
-                        unsafe
-                        {
-                            MakeFCD(new ReadOnlySpan<char>(middle.GetCharsPointer(), middle.Length), ref buffer);
-                        }
+                        MakeFCD(middle.AsSpan(), ref buffer);
                         src = firstBoundaryInSrc;
                     }
                     finally
@@ -2940,9 +2931,9 @@ namespace ICU4N.Impl
         // Called by the Compose() and MakeFCD() implementations.
         // Public in .NET for collation implementation code.
         private int DecomposeShort(
-                ReadOnlySpan<char> s, int src, int limit,
+                scoped ReadOnlySpan<char> s, int src, int limit,
                 bool stopAtCompBoundary, bool onlyContiguous,
-                ref ReorderingBuffer buffer)
+                scoped ref ReorderingBuffer buffer)
         {
             while (src < limit)
             {
@@ -2966,7 +2957,7 @@ namespace ICU4N.Impl
             return src;
         }
 
-        private void Decompose(int c, int norm16, ref ReorderingBuffer buffer)
+        private void Decompose(int c, int norm16, scoped ref ReorderingBuffer buffer)
         {
             // get the decomposition and the lead and trail cc's
             if (norm16 >= limitNoNo)
@@ -3143,7 +3134,7 @@ namespace ICU4N.Impl
         /// a composition may contain at most one more code unit than the original starter,
         /// while the combining mark that is removed has at least one code unit.
         /// </remarks>
-        private void Recompose(ref ReorderingBuffer buffer, int startIndex,
+        private void Recompose(scoped ref ReorderingBuffer buffer, int startIndex,
                                bool onlyContiguous)
         {
             ref ReorderingBuffer sb = ref buffer;

--- a/src/ICU4N/Support/Text/ValueStringBuilder.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.cs
@@ -107,18 +107,6 @@ namespace ICU4N.Text
             return ref MemoryMarshal.GetReference(_chars);
         }
 
-        // ICU4N: Added this to allow inserting one ValueStringBuilder to another
-        // without the compiler complaining about scope. The scoped keyword on 
-        // the ReadOnlySpan<char> parameter of Insert(int, ReadOnlySpan<char>) would
-        // also work, but since that requires LangVersion=>11.0 and that causes more compiler
-        // errors, we are going with this for now. Note we also marked this struct unsafe
-        // just like NumberBuffer is (it wasn't that way originally).
-        public unsafe char* GetCharsPointer()
-        {
-            // This is safe to do since we are a ref struct
-            return (char*)Unsafe.AsPointer(ref _chars[0]);
-        }
-
         public ref char this[int index]
         {
             get
@@ -137,6 +125,9 @@ namespace ICU4N.Text
 
         /// <summary>Returns the underlying storage of the builder.</summary>
         public Span<char> RawChars => _chars;
+
+        /// <summary>Returns the pooled array or <c>null</c> if the stack is still in use.</summary>
+        public char[]? RawArray => _arrayToReturnToPool;
 
         /// <summary>
         /// Returns a memory around the contents of the builder.

--- a/src/ICU4N/Support/Text/ValueStringBuilderPin.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilderPin.cs
@@ -1,0 +1,67 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+#nullable enable
+
+namespace ICU4N.Text
+{
+    /// <summary>
+    /// This is a specialized ref struct used to safely get a pinned pointer to a ValueStringBuilder.
+    /// Pinning using this struct is effectively the same operation as:
+    /// 
+    /// <code>
+    /// fixed (char* charPtr = &amp;sb)
+    /// {
+    ///     // Safe to use charPtr
+    /// }
+    /// </code>
+    /// 
+    /// With the exception that the fixed block is not required and the pin must be undone using <see cref="Free()"/>.
+    /// <para/>
+    /// This allows the use of pinning in the middle of complex business logic without significantly restructuring the
+    /// code.
+    /// <para/>
+    /// Note that a single instance is meant to be used with a single <see cref="ValueStringBuilder"/> instance and
+    /// reentry is not supported. Reuse is allowed, but <see cref="Free()"/> must be called first.
+    /// </summary>
+    internal unsafe ref struct ValueStringBuilderPin
+    {
+        private GCHandle handle;
+        private bool pinned;
+
+        public char* GetSafePointer(ref ValueStringBuilder valueStringBuilder)
+        {
+            // If already pinned, unpin first.
+            if (pinned)
+            {
+                Debug.Assert(true, "We should not need to unpin this. Only one pinned reference is supported at a time.");
+                Free();
+            }
+
+            if (!valueStringBuilder.CapacityExceeded)
+            {
+                // Safe: stack-based
+                pinned = false;
+                return (char*)Unsafe.AsPointer(ref valueStringBuilder.GetPinnableReference());
+            }
+            else
+            {
+                // Unsafe: heap-based, must pin
+                handle = GCHandle.Alloc(valueStringBuilder.RawArray!, GCHandleType.Pinned);
+                pinned = true;
+                return (char*)handle.AddrOfPinnedObject();
+            }
+        }
+
+        public void Free()
+        {
+            if (pinned)
+            {
+                handle.Free();
+                pinned = false;
+            }
+        }
+
+        public void Dispose() => Free();
+    }
+}

--- a/src/ICU4N/Text/FilteredNormalizer2.cs
+++ b/src/ICU4N/Text/FilteredNormalizer2.cs
@@ -60,7 +60,7 @@ namespace ICU4N.Text
         /// <param name="dest">Destination string; its contents is replaced with normalized <paramref name="src"/>.</param>
         /// <returns><paramref name="dest"/></returns>
         /// <stable>ICU 4.4</stable>
-        internal override void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest)
+        internal override void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest)
         {
             if (src.Overlaps(dest.RawChars))
             {
@@ -128,7 +128,7 @@ namespace ICU4N.Text
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal override void NormalizeSecondAndAppend(
-            ref ValueStringBuilder first, ReadOnlySpan<char> second)
+            scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             NormalizeSecondAndAppend(ref first, second, doNormalize: true);
         }
@@ -167,7 +167,7 @@ namespace ICU4N.Text
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal override void Append(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+        internal override void Append(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
         {
             if (first.RawChars.Overlaps(second))
             {
@@ -541,10 +541,7 @@ namespace ICU4N.Text
                             // Not norm2.normalizeSecondAndAppend() because we do not want
                             // to modify the non-filter part of dest.
                             norm2.Normalize(src.Slice(prevSpanLimit, spanLimit - prevSpanLimit), ref tempDest); // ICU4N: Changed 2nd parameter
-                            unsafe
-                            {
-                                dest.Append(new ReadOnlySpan<char>(tempDest.GetCharsPointer(), tempDest.Length));
-                            }
+                            dest.Append(tempDest.AsSpan());
                         }
                         spanCondition = SpanCondition.NotContained;
                     }
@@ -565,7 +562,7 @@ namespace ICU4N.Text
         // <see cref="SpanCondition.Simple"/> should be passed in for the start of src
         // and <see cref="SpanCondition.NotContained"/> should be passed in if we continue after
         // an in-filter prefix.
-        private void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest,
+        private void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest,
                                      SpanCondition spanCondition)
         {
             // Don't throw away destination buffer between iterations.
@@ -592,10 +589,7 @@ namespace ICU4N.Text
                             // Not norm2.normalizeSecondAndAppend() because we do not want
                             // to modify the non-filter part of dest.
                             norm2.Normalize(src.Slice(prevSpanLimit, spanLimit - prevSpanLimit), ref tempDest); // ICU4N: Changed 2nd parameter
-                            unsafe
-                            {
-                                dest.Append(new ReadOnlySpan<char>(tempDest.GetCharsPointer(), tempDest.Length));
-                            }
+                            dest.Append(tempDest.AsSpan());
                         }
                         spanCondition = SpanCondition.NotContained;
                     }
@@ -642,10 +636,8 @@ namespace ICU4N.Text
                             // Not norm2.normalizeSecondAndAppend() because we do not want
                             // to modify the non-filter part of dest.
                             norm2.Normalize(src.Slice(prevSpanLimit, spanLimit - prevSpanLimit), ref tempDest); // ICU4N: Changed 2nd parameter
-                            unsafe
-                            {
-                                dest.Append(new ReadOnlySpan<char>(tempDest.GetCharsPointer(), tempDest.Length));
-                            }
+                            dest.Append(tempDest.AsSpan());
+
                         }
                         spanCondition = SpanCondition.NotContained;
                     }
@@ -663,7 +655,7 @@ namespace ICU4N.Text
 
         #region NormalizeSecondAndAppend(StringBuilder, ICharSequence, bool)
 
-        private void NormalizeSecondAndAppend(ref ValueStringBuilder first, ReadOnlySpan<char> second,
+        private void NormalizeSecondAndAppend(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second,
                                                bool doNormalize)
         {
             if (first.RawChars.Overlaps(second))

--- a/src/ICU4N/Text/Normalizer.cs
+++ b/src/ICU4N/Text/Normalizer.cs
@@ -3354,10 +3354,10 @@ namespace ICU4N.Text
             }
             finally
             {
-                fold1Builder.Dispose();
-                fold2Builder.Dispose();
                 fold1Pin.Dispose();
                 fold2Pin.Dispose();
+                fold1Builder.Dispose();
+                fold2Builder.Dispose();
             }
         }
 

--- a/src/ICU4N/Text/Normalizer.cs
+++ b/src/ICU4N/Text/Normalizer.cs
@@ -2884,7 +2884,9 @@ namespace ICU4N.Text
             CmpEquivLevel* stack2 = stackalloc CmpEquivLevel[2];
 
             /* buffers for algorithmic decompositions */
-            const int DecompositionCharStackBufferSize = 8; // maximum length of 6, but need to be safe because it will fail if not enough
+            //.NET: maximum length of 18 according to UnicodeData.txt. We set to 32 to align for performance.
+            // This aligns with the Java implementation, but the C++ implementation cuts this at 4 chars.
+            const int DecompositionCharStackBufferSize = 32;
             char* decomp1 = stackalloc char[DecompositionCharStackBufferSize];
             char* decomp2 = stackalloc char[DecompositionCharStackBufferSize];
 

--- a/src/ICU4N/Text/Normalizer.cs
+++ b/src/ICU4N/Text/Normalizer.cs
@@ -3,13 +3,9 @@ using ICU4N.Impl;
 using ICU4N.Support;
 using ICU4N.Support.Text;
 using J2N;
-using J2N.IO;
-using J2N.Text;
 using System;
-using System.Buffers;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-using System.Text;
+using System.Runtime.InteropServices;
 using StringBuffer = System.Text.StringBuilder;
 
 namespace ICU4N.Text
@@ -2855,48 +2851,13 @@ namespace ICU4N.Text
          * (Comments in unorm_compare() are more up to date than this TODO.)
          */
 
-        // ICU4N: Refactored the "stack" to use ref structs
+        // ICU4N: Refactored the "stack" to use a ref struct
         /* stack element for previous-level source/decomposition pointers */
         private unsafe ref struct CmpEquivLevel
         {
-            public CmpEquivLevel()
-            {
-                Cs = default;
-                S = default;
-            }
-
-            public ReadOnlySpan<char> Cs { get; set; }
-            public int S { get; set; }
-        }
-
-        private unsafe ref struct StackContainer
-        {
-            private CmpEquivLevel level0;
-            private CmpEquivLevel level1;
-
-            public StackContainer()
-            {
-                level0 = new CmpEquivLevel();
-                level1 = new CmpEquivLevel();
-            }
-
-            public ref CmpEquivLevel this[int index]
-            {
-                get
-                {
-                    switch (index)
-                    {
-                        case 0:
-#pragma warning disable CS9084 // Struct member returns 'this' or other instance members by reference
-                            return ref level0;
-                        case 1:
-                            return ref level1;
-#pragma warning restore CS9084 // Struct member returns 'this' or other instance members by reference
-                        default:
-                            throw new IndexOutOfRangeException(nameof(index));
-                    }
-                }
-            }
+            public char* cs;
+            public int s;
+            public int limit;
         }
 
         /// <summary>
@@ -2905,10 +2866,9 @@ namespace ICU4N.Text
         /// </summary>
         private const int COMPARE_EQUIV = 0x80000;
 
-        /// <summary>
-        /// internal function; package visibility for use by <see cref="UTF16.StringComparer"/>
-        /// </summary>
-        internal static int CmpEquivFold(ReadOnlySpan<char> cs1, ReadOnlySpan<char> cs2, int options) // ICU4N TODO: Port the C++ version because this would be simpler and safer with pointers
+        internal static unsafe int CmpEquivFold(char* cs1, int length1,
+                                                char* cs2, int length2,
+                                                int options)
         {
             Normalizer2Impl nfcImpl;
             UCaseProperties csp;
@@ -2920,58 +2880,74 @@ namespace ICU4N.Text
             int length;
 
             /* stacks of previous-level start/current/limit */
-            StackContainer stack1 = new StackContainer();
-            StackContainer stack2 = new StackContainer();
+            CmpEquivLevel* stack1 = stackalloc CmpEquivLevel[2];
+            CmpEquivLevel* stack2 = stackalloc CmpEquivLevel[2];
 
             /* buffers for algorithmic decompositions */
             const int DecompositionCharStackBufferSize = 8; // maximum length of 6, but need to be safe because it will fail if not enough
-            Span<char> decomp1 = stackalloc char[DecompositionCharStackBufferSize];
-            Span<char> decomp2 = stackalloc char[DecompositionCharStackBufferSize];
+            char* decomp1 = stackalloc char[DecompositionCharStackBufferSize];
+            char* decomp2 = stackalloc char[DecompositionCharStackBufferSize];
+
+            // Spans around decomposition memory, for convenince.
+            Span<char> decomp1Span = new Span<char>(decomp1, DecompositionCharStackBufferSize);
+            Span<char> decomp2Span = new Span<char>(decomp2, DecompositionCharStackBufferSize);
 
             /* case folding buffers, only use current-level start/limit */
-            var fold1 = new ValueStringBuilder(stackalloc char[UCaseProperties.MaxStringLength + 1]);
-            var fold2 = new ValueStringBuilder(stackalloc char[UCaseProperties.MaxStringLength + 1]);
+            const int FoldCharStackBufferSize = UCaseProperties.MaxStringLength + 1;
+            char* fold1 = stackalloc char[FoldCharStackBufferSize];
+            char* fold2 = stackalloc char[FoldCharStackBufferSize];
+
+            // Spans around folding memory, for convenince.
+            Span<char> fold1Span = new Span<char>(fold1, FoldCharStackBufferSize);
+            Span<char> fold2Span = new Span<char>(fold2, FoldCharStackBufferSize);
+
+            /* track which is the current level per string */
+            int level1, level2;
+
+            /* current code units, and code points for lookups */
+            int c1, c2, cp1, cp2;
+
+            /* no argument error checking because this itself is not an API */
+
+            /*
+             * assume that at least one of the options _COMPARE_EQUIV and U_COMPARE_IGNORE_CASE is set
+             * otherwise this function must behave exactly as uprv_strCompare()
+             * not checking for that here makes testing this function easier
+             */
+
+            /* normalization/properties data loaded? */
+            if ((options & COMPARE_EQUIV) != 0)
+            {
+                nfcImpl = Norm2AllModes.NFCInstance.Impl;
+            }
+            else
+            {
+                nfcImpl = null;
+            }
+            if ((options & COMPARE_IGNORE_CASE) != 0)
+            {
+                csp = UCaseProperties.Instance;
+                // ICU4N: fold1, fold2 instantiated on stack above
+            }
+            else
+            {
+                csp = null;
+            }
+
+            // Builders to get foldings.
+            var fold1Builder = new ValueStringBuilder(fold1Span);
+            var fold2Builder = new ValueStringBuilder(fold2Span);
+            // Pins in case we overflow the stack. This keeps the pointers to backing arrays
+            // in scope until we are done.
+            var fold1Pin = new ValueStringBuilderPin();
+            var fold2Pin = new ValueStringBuilderPin();
             try
             {
-
-                /* track which is the current level per string */
-                int level1, level2;
-
-                /* current code units, and code points for lookups */
-                int c1, c2, cp1, cp2;
-
-                /* no argument error checking because this itself is not an API */
-
-                /*
-                 * assume that at least one of the options _COMPARE_EQUIV and U_COMPARE_IGNORE_CASE is set
-                 * otherwise this function must behave exactly as uprv_strCompare()
-                 * not checking for that here makes testing this function easier
-                 */
-
-                /* normalization/properties data loaded? */
-                if ((options & COMPARE_EQUIV) != 0)
-                {
-                    nfcImpl = Norm2AllModes.NFCInstance.Impl;
-                }
-                else
-                {
-                    nfcImpl = null;
-                }
-                if ((options & COMPARE_IGNORE_CASE) != 0)
-                {
-                    csp = UCaseProperties.Instance;
-                    // ICU4N: fold1, fold2 instantiated on stack above
-                }
-                else
-                {
-                    csp = null;
-                }
-
                 /* initialize */
                 s1 = 0;
-                limit1 = cs1.Length;
+                limit1 = length1;
                 s2 = 0;
-                limit2 = cs2.Length;
+                limit2 = length2;
 
                 level1 = level2 = 0;
                 c1 = c2 = -1;
@@ -3007,10 +2983,10 @@ namespace ICU4N.Text
                             do
                             {
                                 --level1;
-                                cs1 = stack1[level1].Cs;
-                            } while (cs1 == null);
-                            s1 = stack1[level1].S;
-                            limit1 = cs1.Length;
+                                cs1 = stack1[level1].cs;                /*Not uninitialized*/
+                            } while (cs1 is null);
+                            s1 = stack1[level1].s;
+                            limit1 = stack1[level1].limit;
                         }
                     }
 
@@ -3037,10 +3013,10 @@ namespace ICU4N.Text
                             do
                             {
                                 --level2;
-                                cs2 = stack2[level2].Cs;
-                            } while (cs2 == null);
-                            s2 = stack2[level2].S;
-                            limit2 = cs2.Length;
+                                cs2 = stack2[level2].cs;                /*Not uninitialized*/
+                            } while (cs2 is null);
+                            s2 = stack2[level2].s;
+                            limit2 = stack2[level2].limit;
                         }
                     }
 
@@ -3118,7 +3094,7 @@ namespace ICU4N.Text
                      */
 
                     if (level1 == 0 && (options & COMPARE_IGNORE_CASE) != 0 &&
-                        (length = csp.ToFullFolding(cp1, ref fold1, options)) >= 0)
+                        (length = csp.ToFullFolding(cp1, ref fold1Builder, options)) >= 0)
                     {
                         /* cp1 case-folds to the code point "length" or to p[length] */
                         if (UTF16.IsSurrogate((char)c1))
@@ -3143,29 +3119,29 @@ namespace ICU4N.Text
                         }
 
                         /* push current level pointers */
-                        stack1[0].Cs = cs1;
-                        stack1[0].S = s1;
+                        /* .NET: The stack1 buffer was instantiated on the stack above */
+                        stack1[0].cs = cs1;
+                        stack1[0].s = s1;
+                        stack1[0].limit = limit1;
                         ++level1;
 
                         /* copy the folding result to fold1[] */
-                        /* Java: the buffer was probably not empty, remove the old contents */
+                        /* .NET: the buffer was probably not empty, remove the old contents */
                         if (length <= UCaseProperties.MaxStringLength)
                         {
-                            fold1.Delete(0, (fold1.Length - length) - 0); // ICU4N: Corrected 2nd parameter of Delete
+                            fold1Builder.Delete(0, (fold1Builder.Length - length)); // ICU4N: Checked 2nd parameter of Delete
                         }
                         else
                         {
-                            fold1.Length = 0;
-                            fold1.AppendCodePoint(length);
+                            fold1Builder.Length = 0;
+                            fold1Builder.AppendCodePoint(length);
                         }
 
                         /* set next level pointers to case folding */
-                        unsafe
-                        {
-                            cs1 = new ReadOnlySpan<char>(fold1.GetCharsPointer(), fold1.Length);
-                        }
+                        // .NET: We need to get a pinned pointer if we are on the heap so the GC doesn't collect it before we are done
+                        cs1 = fold1Pin.GetSafePointer(ref fold1Builder);
                         s1 = 0;
-                        limit1 = fold1.Length;
+                        limit1 = fold1Builder.Length;
 
                         /* get ready to read from decomposition, continue with loop */
                         c1 = -1;
@@ -3173,7 +3149,7 @@ namespace ICU4N.Text
                     }
 
                     if (level2 == 0 && (options & COMPARE_IGNORE_CASE) != 0 &&
-                        (length = csp.ToFullFolding(cp2, ref fold2, options)) >= 0
+                        (length = csp.ToFullFolding(cp2, ref fold2Builder, options)) >= 0
                     )
                     {
                         /* cp2 case-folds to the code point "length" or to p[length] */
@@ -3199,29 +3175,29 @@ namespace ICU4N.Text
                         }
 
                         /* push current level pointers */
-                        stack2[0].Cs = cs2;
-                        stack2[0].S = s2;
+                        /* .NET: The stack2 buffer was instantiated on the stack above */
+                        stack2[0].cs = cs2;
+                        stack2[0].s = s2;
+                        stack2[0].limit = limit2;
                         ++level2;
 
                         /* copy the folding result to fold2[] */
-                        /* Java: the buffer was probably not empty, remove the old contents */
+                        /* .NET: the buffer was probably not empty, remove the old contents */
                         if (length <= UCaseProperties.MaxStringLength)
                         {
-                            fold2.Delete(0, (fold2.Length - length) - 0); // ICU4N: Corrected 2nd parameter of Delete
+                            fold2Builder.Delete(0, (fold2Builder.Length - length)); // ICU4N: Checked 2nd parameter of Delete
                         }
                         else
                         {
-                            fold2.Length = 0;
-                            fold2.AppendCodePoint(length);
+                            fold2Builder.Length = 0;
+                            fold2Builder.AppendCodePoint(length);
                         }
 
                         /* set next level pointers to case folding */
-                        unsafe
-                        {
-                            cs2 = new ReadOnlySpan<char>(fold2.GetCharsPointer(), fold2.Length);
-                        }
+                        // .NET: We need to get a pinned pointer if we are on the heap so the GC doesn't collect it before we are done
+                        cs2 = fold2Pin.GetSafePointer(ref fold2Builder);
                         s2 = 0;
-                        limit2 = fold2.Length;
+                        limit2 = fold2Builder.Length;
 
                         /* get ready to read from decomposition, continue with loop */
                         c2 = -1;
@@ -3229,7 +3205,7 @@ namespace ICU4N.Text
                     }
 
                     if (level1 < 2 && (options & COMPARE_EQUIV) != 0 &&
-                        nfcImpl.TryGetDecomposition(cp1, decomp1, out int decomp1Length)
+                        nfcImpl.TryGetDecomposition(cp1, decomp1Span, out length)
                     )
                     {
                         /* cp1 decomposes into p[length] */
@@ -3255,23 +3231,21 @@ namespace ICU4N.Text
                         }
 
                         /* push current level pointers */
-                        stack1[level1].Cs = cs1;
-                        stack1[level1].S = s1;
+                        stack1[level1].cs = cs1;
+                        stack1[level1].s = s1;
+                        stack1[level1].limit = limit1;
                         ++level1;
 
                         /* set empty intermediate level if skipped */
                         if (level1 < 2)
                         {
-                            stack1[level1++].Cs = null;
+                            stack1[level1++].cs = null;
                         }
 
                         /* set next level pointers to decomposition */
-                        unsafe
-                        {
-                            cs1 = new ReadOnlySpan<char>((char*)Unsafe.AsPointer(ref decomp1[0]), decomp1Length);
-                        }
+                        cs1 = decomp1;
                         s1 = 0;
-                        limit1 = decomp1Length;
+                        limit1 = length;
 
                         /* get ready to read from decomposition, continue with loop */
                         c1 = -1;
@@ -3279,7 +3253,7 @@ namespace ICU4N.Text
                     }
 
                     if (level2 < 2 && (options & COMPARE_EQUIV) != 0 &&
-                        nfcImpl.TryGetDecomposition(cp2, decomp2, out int decomp2Length)
+                        nfcImpl.TryGetDecomposition(cp2, decomp2Span, out length)
                     )
                     {
                         /* cp2 decomposes into p[length] */
@@ -3305,23 +3279,21 @@ namespace ICU4N.Text
                         }
 
                         /* push current level pointers */
-                        stack2[level2].Cs = cs2;
-                        stack2[level2].S = s2;
+                        stack2[level2].cs = cs2;
+                        stack2[level2].s = s2;
+                        stack2[level2].limit = limit2;
                         ++level2;
 
                         /* set empty intermediate level if skipped */
                         if (level2 < 2)
                         {
-                            stack2[level2++].Cs = null;
+                            stack2[level2++].cs = null;
                         }
 
                         /* set next level pointers to decomposition */
-                        unsafe
-                        {
-                            cs2 = new ReadOnlySpan<char>((char*)Unsafe.AsPointer(ref decomp2[0]), decomp2Length);
-                        }
+                        cs2 = decomp2;
                         s2 = 0;
-                        limit2 = decomp2Length;
+                        limit2 = length;
 
                         /* get ready to read from decomposition, continue with loop */
                         c2 = -1;
@@ -3380,8 +3352,21 @@ namespace ICU4N.Text
             }
             finally
             {
-                fold1.Dispose();
-                fold2.Dispose();
+                fold1Builder.Dispose();
+                fold2Builder.Dispose();
+                fold1Pin.Dispose();
+                fold2Pin.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// internal function; package visibility for use by <see cref="UTF16.StringComparer"/>
+        /// </summary>
+        internal unsafe static int CmpEquivFold(ReadOnlySpan<char> cs1, ReadOnlySpan<char> cs2, int options)
+        {
+            fixed(char* cs1Ptr = &MemoryMarshal.GetReference(cs1), cs2Ptr = &MemoryMarshal.GetReference(cs2))
+            {
+                return CmpEquivFold(cs1Ptr, cs1.Length, cs2Ptr, cs2.Length, options);
             }
         }
 

--- a/src/ICU4N/Text/Normalizer.cs
+++ b/src/ICU4N/Text/Normalizer.cs
@@ -2908,7 +2908,7 @@ namespace ICU4N.Text
         /// <summary>
         /// internal function; package visibility for use by <see cref="UTF16.StringComparer"/>
         /// </summary>
-        internal static int CmpEquivFold(ReadOnlySpan<char> cs1, ReadOnlySpan<char> cs2, int options)
+        internal static int CmpEquivFold(ReadOnlySpan<char> cs1, ReadOnlySpan<char> cs2, int options) // ICU4N TODO: Port the C++ version because this would be simpler and safer with pointers
         {
             Normalizer2Impl nfcImpl;
             UCaseProperties csp;
@@ -2924,14 +2924,13 @@ namespace ICU4N.Text
             StackContainer stack2 = new StackContainer();
 
             /* buffers for algorithmic decompositions */
-            const int DecompositionCharStackBufferSize = 16; // maximum length of 6, but need to be safe because it will fail if not enough
+            const int DecompositionCharStackBufferSize = 8; // maximum length of 6, but need to be safe because it will fail if not enough
             Span<char> decomp1 = stackalloc char[DecompositionCharStackBufferSize];
             Span<char> decomp2 = stackalloc char[DecompositionCharStackBufferSize];
 
             /* case folding buffers, only use current-level start/limit */
-            const int FoldCharStackBufferSize = 8; // maximum length of 3
-            var fold1 = new ValueStringBuilder(stackalloc char[FoldCharStackBufferSize]);
-            var fold2 = new ValueStringBuilder(stackalloc char[FoldCharStackBufferSize]);
+            var fold1 = new ValueStringBuilder(stackalloc char[UCaseProperties.MaxStringLength + 1]);
+            var fold2 = new ValueStringBuilder(stackalloc char[UCaseProperties.MaxStringLength + 1]);
             try
             {
 

--- a/src/ICU4N/Text/Normalizer2.cs
+++ b/src/ICU4N/Text/Normalizer2.cs
@@ -444,7 +444,7 @@ namespace ICU4N.Text
         /// <paramref name="src"/> and <paramref name="dest"/> refer to the same memory location.
         /// </exception>
         /// <draft>ICU 60.1</draft>
-        internal abstract void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest);
+        internal abstract void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest);
 
         #endregion Normalize(ICharSequence, StringBuilder)
 
@@ -537,7 +537,7 @@ namespace ICU4N.Text
         /// </exception>
         /// <draft>ICU 60.1</draft>
         internal abstract void NormalizeSecondAndAppend(
-            ref ValueStringBuilder first, ReadOnlySpan<char> second);
+            scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second);
 
         #endregion
 
@@ -589,7 +589,7 @@ namespace ICU4N.Text
         /// <paramref name="first"/> and <paramref name="second"/> refer to the same memory location.
         /// </exception>
         /// <stable>ICU 4.4</stable>
-        internal abstract void Append(ref ValueStringBuilder first, ReadOnlySpan<char> second);
+        internal abstract void Append(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second);
 
         #endregion Append(StringBuilder, ICharSequence)
 

--- a/src/ICU4N/Text/UTF16.cs
+++ b/src/ICU4N/Text/UTF16.cs
@@ -2509,10 +2509,13 @@ namespace ICU4N.Text
             /// <param name="s2">Second string to compare.</param>
             /// <returns>-1 if <paramref name="s1"/> &lt; <paramref name="s2"/>, 0 if equal, 
             /// 1 if <paramref name="s1"/> &gt; <paramref name="s2"/>.</returns>
-            private int CompareCaseInsensitive(string s1, string s2)
+            private unsafe int CompareCaseInsensitive(string s1, string s2)
             {
-                return Normalizer.CmpEquivFold(s1.AsSpan(), s2.AsSpan(), m_foldCase_ | m_codePointCompare_
-                        | Normalizer.COMPARE_IGNORE_CASE);
+                fixed (char* s1Ptr = s1, s2Ptr = s2)
+                {
+                    return Normalizer.CmpEquivFold(s1Ptr, s1.Length, s2Ptr, s2.Length, m_foldCase_ | m_codePointCompare_
+                            | Normalizer.COMPARE_IGNORE_CASE);
+                }
             }
 
             /// <summary>

--- a/tests/ICU4N.Tests/Dev/Test/Normalizers/BasicTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Normalizers/BasicTest.cs
@@ -3164,7 +3164,7 @@ namespace ICU4N.Dev.Test.Normalizers
 
             public override StringBuffer Normalize(ReadOnlySpan<char> src, StringBuffer dest) => null;
 
-            internal override void Normalize(scoped ReadOnlySpan<char> src, ref ValueStringBuilder dest)
+            internal override void Normalize(scoped ReadOnlySpan<char> src, scoped ref ValueStringBuilder dest)
             {
             }
 
@@ -3172,13 +3172,13 @@ namespace ICU4N.Dev.Test.Normalizers
 
             public override StringBuffer NormalizeSecondAndAppend(StringBuffer first, ReadOnlySpan<char> second) => null;
 
-            internal override void NormalizeSecondAndAppend(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+            internal override void NormalizeSecondAndAppend(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
             {
             }
 
             public override StringBuffer Append(StringBuffer first, ReadOnlySpan<char> second) => null;
 
-            internal override void Append(ref ValueStringBuilder first, ReadOnlySpan<char> second)
+            internal override void Append(scoped ref ValueStringBuilder first, scoped ReadOnlySpan<char> second)
             {
             }
 


### PR DESCRIPTION
This addresses a few issues in Normalizer and Normalizer2 where pointers were being utilized to create spans to work around compile issues prior to LangVersion 11.0, which added the `scoped` keyword to certify to the compiler that access to the memory is safe. Unfortunately, the workaround created potential issues when the memory spills over into the heap as there are no guarantees that the pointers will remain valid unless they are pinned.

In the case of the `Normalizer.CmpEquivFold()`, a `ValueStringBuilderPin` ref struct was made to pin the pointer at the point where it is accessed. Since it is in the middle of a loop, using `fixed` to pin the pointer is impractical without significant refactoring of the business logic, so this was a better option to stay aligned with the upstream code. `ValueStringBuilderPin` could have been part of `ValueStringBuilder`, but it didn't seem like the overhead was worth it for all use cases.

This should fix https://github.com/apache/lucenenet/issues/1135, but since it wasn't possible to reproduce the issue, it cannot be confirmed other than through repetitive testing.