### PR TITLE
J2N.Text (OpenStringBuilder + ValueStringBuilder): Added Append(char[], int, int) overload and removed `Append(ReadOnlySpan<char>, int, int)` 

### DIFF
--- a/src/ICU4N.Collation/Impl/Coll/CollationBuilder.cs
+++ b/src/ICU4N.Collation/Impl/Coll/CollationBuilder.cs
@@ -1139,9 +1139,9 @@ namespace ICU4N.Impl.Coll
             // into the nfdString's last starter and the combining marks following it.
             // Make an NFD version, and a version with the composite.
             newNFDString.Length = 0;
-            newNFDString.Append(nfdString, 0, indexAfterLastStarter - 0); // ICU4N: Checked 3rd parameter
+            newNFDString.Append(nfdString.Slice(0, indexAfterLastStarter)); // ICU4N: Checked length parameter
             newString.Length = 0;
-            newString.Append(nfdString, 0, (indexAfterLastStarter - lastStarterLength) - 0); // ICU4N: Checked 3rd parameter
+            newString.Append(nfdString.Slice(0, indexAfterLastStarter - lastStarterLength)); // ICU4N: Checked length parameter
             newString.AppendCodePoint(composite);
 
             // The following is related to discontiguous contraction matching,
@@ -1208,12 +1208,12 @@ namespace ICU4N.Impl.Coll
                     // Appending the next source character to the composite would not be FCD.
                     return false;
                 }
-                newNFDString.Append(nfdString, sourceIndex, nfdString.Length - sourceIndex); // ICU4N: Corrected 3rd parameter
-                newString.Append(nfdString, sourceIndex, nfdString.Length - sourceIndex); // ICU4N: Corrected 3rd parameter
+                newNFDString.Append(nfdString.Slice(sourceIndex, nfdString.Length - sourceIndex)); // ICU4N: Corrected length parameter
+                newString.Append(nfdString.Slice(sourceIndex, nfdString.Length - sourceIndex)); // ICU4N: Corrected length parameter
             }
             else if (decompIndex < decomp.Length)
             {  // more characters from decomp, not from nfdString
-                newNFDString.Append(decomp, decompIndex, decomp.Length - decompIndex); // ICU4N: Corrected 3rd parameter
+                newNFDString.Append(decomp.Slice(decompIndex, decomp.Length - decompIndex)); // ICU4N: Corrected length parameter
             }
             Debug.Assert(nfd.IsNormalized(newNFDString.AsSpan()));
             Debug.Assert(fcd.IsNormalized(newString.AsSpan()));

--- a/src/ICU4N/Impl/Normalizer2Impl.cs
+++ b/src/ICU4N/Impl/Normalizer2Impl.cs
@@ -2361,9 +2361,9 @@ namespace ICU4N.Impl
                         : new ValueStringBuilder(middleLength);
                     try
                     {
-                        middle.Append(buffer.AsSpan(), lastStarterInDest, buffer.Length - lastStarterInDest); // ICU4N : Fixed 3rd parameter
+                        middle.Append(buffer.AsSpan(lastStarterInDest, buffer.Length - lastStarterInDest)); // ICU4N : Fixed length parameter
                         buffer.RemoveSuffix(buffer.Length - lastStarterInDest);
-                        middle.Append(s, 0, firstStarterInSrc - 0);
+                        middle.Append(s.Slice(0, firstStarterInSrc - 0));
                         Compose(middle.AsSpan(), onlyContiguous, true, ref buffer);
                         src = firstStarterInSrc;
                     }
@@ -2375,7 +2375,7 @@ namespace ICU4N.Impl
             }
             if (doCompose)
             {
-                Compose(s.Slice(src, limit - src), onlyContiguous, true, ref buffer); // ICU4N: Corrected 3rd parameter
+                Compose(s.Slice(src, limit - src), onlyContiguous, true, ref buffer); // ICU4N: Corrected length parameter
             }
             else
             {
@@ -2705,9 +2705,9 @@ namespace ICU4N.Impl
                         : new ValueStringBuilder(middleLength);
                     try
                     {
-                        middle.Append(buffer.AsSpan(), lastBoundaryInDest, buffer.Length - lastBoundaryInDest); // ICU4N : Fixed 3rd parameter
+                        middle.Append(buffer.AsSpan(lastBoundaryInDest, buffer.Length - lastBoundaryInDest)); // ICU4N : Fixed length parameter
                         buffer.RemoveSuffix(buffer.Length - lastBoundaryInDest);
-                        middle.Append(s, 0, firstBoundaryInSrc - 0);
+                        middle.Append(s.Slice(0, firstBoundaryInSrc - 0));
                         MakeFCD(middle.AsSpan(), ref buffer);
                         src = firstBoundaryInSrc;
                     }
@@ -2719,7 +2719,7 @@ namespace ICU4N.Impl
             }
             if (doMakeFCD)
             {
-                MakeFCD(s.Slice(src, limit - src), ref buffer); // ICU4N: Corrected 3rd parameter
+                MakeFCD(s.Slice(src, limit - src), ref buffer); // ICU4N: Corrected length parameter
             }
             else
             {

--- a/src/ICU4N/Support/Text/OpenStringBuilder.Appendable.cs
+++ b/src/ICU4N/Support/Text/OpenStringBuilder.Appendable.cs
@@ -35,7 +35,7 @@ namespace ICU4N.Text
                 Grow(count);
             }
 
-            value.CopyTo(startIndex, _chars, _pos, count);
+            value.CopyTo(startIndex, _chars, pos, count);
             _pos += count;
             return this;
         }
@@ -75,7 +75,7 @@ namespace ICU4N.Text
                 Grow(count);
             }
 
-            value.CopyTo(startIndex, _chars, _pos, count);
+            value.CopyTo(startIndex, _chars, pos, count);
             _pos += count;
             return this;
         }

--- a/src/ICU4N/Support/Text/OpenStringBuilder.Appendable.cs
+++ b/src/ICU4N/Support/Text/OpenStringBuilder.Appendable.cs
@@ -1,10 +1,7 @@
 ﻿using J2N.Text;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 #nullable enable
 
 namespace ICU4N.Text
@@ -26,16 +23,40 @@ namespace ICU4N.Text
 
         public OpenStringBuilder Append(string? value, int startIndex, int count)
         {
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert(value is null || value.Length - startIndex >= count);
+
             if (value is null || count == 0) return this;
 
-            return Append(value.AsSpan(startIndex, count));
+            int pos = _pos;
+            if (pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            value.CopyTo(startIndex, _chars, _pos, count);
+            _pos += count;
+            return this;
         }
 
-        public OpenStringBuilder Append(ReadOnlySpan<char> value, int startIndex, int count)
+        public OpenStringBuilder Append(char[]? value, int startIndex, int count)
         {
-            if (value == default || count == 0) return this;
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert(value is null || value.Length - startIndex >= count);
 
-            return Append(value.Slice(startIndex, count));
+            if (value is null || count == 0) return this;
+
+            int pos = _pos;
+            if (pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Array.Copy(value, startIndex, _chars, pos, count);
+            _pos += count;
+            return this;
         }
 
         public OpenStringBuilder Append(StringBuilder? value) => Append(value, 0, value?.Length ?? 0);

--- a/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
@@ -58,16 +58,40 @@ namespace ICU4N.Text
 
         public void Append(string? value, int startIndex, int count)
         {
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert(value is null || value?.Length - startIndex >= count);
+
             if (value is null || count == 0) return;
 
-            Append(value.AsSpan(startIndex, count));
+            int pos = _pos;
+            if (pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            value.AsSpan(startIndex, count).CopyTo(_chars.Slice(pos, count));
+            _pos += count;
+            UpdateMaxLength();
         }
 
-        public void Append(scoped ReadOnlySpan<char> value, int startIndex, int count)
+        public void Append(char[]? value, int startIndex, int count)
         {
-            if (value == default || count == 0) return;
+            Debug.Assert(startIndex >= 0);
+            Debug.Assert(count >= 0);
+            Debug.Assert(value is null || value?.Length - startIndex >= count);
 
-            Append(value.Slice(startIndex, count));
+            if (value is null || count == 0) return;
+
+            int pos = _pos;
+            if (pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            value.AsSpan(startIndex, count).CopyTo(_chars.Slice(pos, count));
+            _pos += count;
+            UpdateMaxLength();
         }
 
         public void Append(StringBuilder? value) => Append(value, 0, value?.Length ?? 0);

--- a/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
@@ -113,12 +113,12 @@ namespace ICU4N.Text
             if (_arrayToReturnToPool is null)
             {
                 // Only call our extension method (which may allocate a buffer) if we have to.
-                value.CopyTo(startIndex, _chars.Slice(_pos), count);
+                value.CopyTo(startIndex, _chars.Slice(pos), count);
             }
             else
             {
                 // If we are already on the heap, we can use CopyTo(int, char[], int, int) for better efficiency
-                value.CopyTo(startIndex, _arrayToReturnToPool, _pos, count);
+                value.CopyTo(startIndex, _arrayToReturnToPool, pos, count);
             }
             _pos += count;
             UpdateMaxLength();

--- a/src/ICU4N/Util/CharsTrie.cs
+++ b/src/ICU4N/Util/CharsTrie.cs
@@ -244,10 +244,10 @@ namespace ICU4N.Util
                     int length = node - CharsTrie.kMinLinearMatch + 1;
                     if (maxLength_ > 0 && str_.Length + length > maxLength_)
                     {
-                        str_.Append(chars_, pos, maxLength_ - str_.Length); // ICU4N: (pos + maxLength_ - str_.Length) - pos == (maxLength_ - str_.Length)
+                        str_.Append(chars_.Slice(pos, maxLength_ - str_.Length)); // ICU4N: (pos + maxLength_ - str_.Length) - pos == (maxLength_ - str_.Length)
                         return TruncateAndStop();
                     }
-                    str_.Append(chars_, pos, length); // ICU4N: (pos + length) - pos == length
+                    str_.Append(chars_.Slice(pos, length)); // ICU4N: (pos + length) - pos == length
                     pos += length;
                 }
             }

--- a/src/ICU4N/Util/StringTrieBuilder.cs
+++ b/src/ICU4N/Util/StringTrieBuilder.cs
@@ -976,7 +976,7 @@ namespace ICU4N.Util
             {
 #pragma warning disable 612, 618
                 int offset = strings.Length;
-                strings.Append(s, start, s.Length - start); // ICU4N: Corrected 3rd parameter
+                strings.Append(s.Slice(start, s.Length - start)); // ICU4N: Corrected 3rd parameter
                 node = new LinearMatchNode(strings, offset, s.Length - start, node);
 #pragma warning restore 612, 618
             }


### PR DESCRIPTION
Added the `Append(char[], int, int)` overload and removed the `Append(ReadOnlySpan<char>, int, int)` overload, since the parameters are redundant with spans. Added more robust parameter checking and complete implementation rather than a cascade, which is slower.

A reason for doing this is to move away from checking `ReadOnlySpan<char>` against `default`, which is warned about in `net9.0`+.