### PR TITLE
Fixed usage of ConcurrentDictionary<TKey, TValue> to use Lazy<T> when it matters (Fixes #115)

### DIFF
--- a/src/ICU4N.Transliterator/Text/NormalizationTransliterator.cs
+++ b/src/ICU4N.Transliterator/Text/NormalizationTransliterator.cs
@@ -174,7 +174,7 @@ namespace ICU4N.Text
             offsets.Limit = limit;
         }
 
-        internal static readonly ConcurrentDictionary<Normalizer2, SourceTargetUtility> SOURCE_CACHE = new ConcurrentDictionary<Normalizer2, SourceTargetUtility>();
+        internal static readonly ConcurrentDictionary<Normalizer2, Lazy<SourceTargetUtility>> SOURCE_CACHE = new ConcurrentDictionary<Normalizer2, Lazy<SourceTargetUtility>>();
 
         // TODO Get rid of this if Normalizer2 becomes a Transform
         internal class NormalizingTransform : ITransform<string, string>
@@ -196,7 +196,8 @@ namespace ICU4N.Text
         public override void AddSourceTargetSet(UnicodeSet inputFilter, UnicodeSet sourceSet, UnicodeSet targetSet)
 #pragma warning restore 672
         {
-            SourceTargetUtility cache = SOURCE_CACHE.GetOrAdd(norm2, (norm2) => new SourceTargetUtility(new NormalizingTransform(norm2), norm2));
+            SourceTargetUtility cache = SOURCE_CACHE.GetOrAdd(norm2, (norm2) =>
+                new Lazy<SourceTargetUtility>(() => new SourceTargetUtility(new NormalizingTransform(norm2), norm2))).Value;
             cache.AddSourceTargetSet(this, inputFilter, sourceSet, targetSet);
         }
     }

--- a/src/ICU4N/Util/VersionInfo.cs
+++ b/src/ICU4N/Util/VersionInfo.cs
@@ -15,7 +15,7 @@ namespace ICU4N.Util
         /// <summary>
         /// Map of singletons
         /// </summary>
-        private static readonly ConcurrentDictionary<int, VersionInfo> MAP_ = new ConcurrentDictionary<int, VersionInfo>();
+        private static readonly ConcurrentDictionary<int, Lazy<VersionInfo>> MAP_ = new ConcurrentDictionary<int, Lazy<VersionInfo>>();
 
         // public data members -------------------------------------------------
 
@@ -333,7 +333,7 @@ namespace ICU4N.Util
             int key = GetInt32(major, minor, milli, micro);
             int version = key;
 
-            return MAP_.GetOrAdd(version, (version) => new VersionInfo(version));
+            return MAP_.GetOrAdd(version, (version) => new Lazy<VersionInfo>(() => new VersionInfo(version))).Value;
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses issues that may arise when using `ConcurrentDictionary<TKey, TValue>` without having a `Lazy<T>` value. `Lazy<T>` combined with `GetOrAddValue()` ensures only one thread can create the cached value and all threads share the same value.

Fixes #115.