### PR TITLE
Added BinarySerializer support for .NET 8+ tests

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -21,6 +21,7 @@
     <SystemReflectionMetadataPackageReferenceVersion Condition=" '$(TargetFramework)' == 'net451' ">1.8.1</SystemReflectionMetadataPackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>6.0.0</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
     <SystemRuntimeCompilerServicesUnsafePackageReferenceVersion Condition=" '$(TargetFramework)' == 'net451' ">4.7.1</SystemRuntimeCompilerServicesUnsafePackageReferenceVersion>
+    <SystemRuntimeSerializationFormattersPackageReferenceVersion>10.0.0</SystemRuntimeSerializationFormattersPackageReferenceVersion>
     <SystemTextRegularExpressionsPackageReferenceVersion>4.3.1</SystemTextRegularExpressionsPackageReferenceVersion>
   </PropertyGroup>
   <PropertyGroup Label=".NET Tool Package Versions">

--- a/tests/Directory.Build.targets
+++ b/tests/Directory.Build.targets
@@ -2,78 +2,13 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.targets', '$(MSBuildThisFileDirectory)../'))" />
   <Import Project="$(SolutionDir)/.build/TestReferences.Common.targets" />
 
-  <UsingTask TaskName="UpdateRuntimeConfigProperty" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
-    <ParameterGroup>
-      <RuntimeConfigFile ParameterType="System.String" Required="true" />
-      <PropertyName ParameterType="System.String" Required="true" />
-      <PropertyValue ParameterType="System.String" Required="true" />
-    </ParameterGroup>
-    <Task>
-      <Using Namespace="System.IO" />
-      <Using Namespace="System.Text" />
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[
-        if (File.Exists(RuntimeConfigFile))
-        {
-            // Read the file content
-            string jsonContent = File.ReadAllText(RuntimeConfigFile);
+  <PropertyGroup Label="Binary Serializer Support">
+    <RequiresSerializationPatch  Condition=" !$(TargetFramework.StartsWith('net4')) And !$(TargetFramework.StartsWith('netstandard')) And !$(TargetFramework.StartsWith('net6.')) And !$(TargetFramework.StartsWith('net7.')) ">true</RequiresSerializationPatch>
+    <EnableUnsafeBinaryFormatterSerialization Condition="'$(RequiresSerializationPatch)' == 'true'">true</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
 
-            // Ensure runtimeOptions and configProperties sections exist
-            if (!jsonContent.Contains("\"runtimeOptions\""))
-            {
-                jsonContent = jsonContent.TrimEnd('}', '\n', '\r') + ",\n  \"runtimeOptions\": {\n    \"configProperties\": {\n    }\n  }\n}";
-            }
-            if (!jsonContent.Contains("\"configProperties\""))
-            {
-                int runtimeOptionsIndex = jsonContent.IndexOf("\"runtimeOptions\"");
-                int insertPosition = jsonContent.IndexOf('}', runtimeOptionsIndex);
-                jsonContent = jsonContent.Insert(insertPosition, ",\n    \"configProperties\": {\n    }\n");
-            }
+  <ItemGroup Label="Binary Serializer Support" Condition="'$(RequiresSerializationPatch)' == 'true' ">
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="$(SystemRuntimeSerializationFormattersPackageReferenceVersion)" />
+  </ItemGroup>
 
-            // Check if the property already exists
-            int configPropertiesIndex = jsonContent.IndexOf("\"configProperties\"");
-            int propertyIndex = jsonContent.IndexOf("\"" + PropertyName + "\"", configPropertiesIndex);
-
-            if (propertyIndex != -1)
-            {
-                // Property exists, update its value
-                int valueStartIndex = jsonContent.IndexOf(':', propertyIndex) + 1;
-                int valueEndIndex = jsonContent.IndexOfAny(new char[] { ',', '}', '\n' }, valueStartIndex);
-                jsonContent = jsonContent.Remove(valueStartIndex, valueEndIndex - valueStartIndex)
-                                         .Insert(valueStartIndex, " " + PropertyValue);
-            }
-            else
-            {
-                // Property does not exist, add it
-                int closingBraceIndex = jsonContent.IndexOf('}', configPropertiesIndex);
-                jsonContent = jsonContent.Insert(closingBraceIndex, "  \"" + PropertyName + "\": " + PropertyValue + ",\n");
-            }
-
-            // Write the updated content back to the file
-            File.WriteAllText(RuntimeConfigFile, jsonContent);
-        }
-        else
-        {
-            Log.LogError("File not found: " + RuntimeConfigFile);
-        }
-        ]]>
-      </Code>
-    </Task>
-  </UsingTask>
-
-  <!-- Target to invoke the task after build -->
-  <Target Name="UpdateRuntimeConfig" AfterTargets="Build">
-    <PropertyGroup>
-      <RuntimeConfigFile>$(TargetDir)$(AssemblyName).runtimeconfig.json</RuntimeConfigFile>
-      <DotNet_8_0_OrGreater>false</DotNet_8_0_OrGreater>
-      <DotNet_8_0_OrGreater Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' And ($(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or ($(TargetFramework.StartsWith('net')) And $(TargetFramework.IndexOf('.')) > 4))">true</DotNet_8_0_OrGreater>
-    </PropertyGroup>
-
-    <UpdateRuntimeConfigProperty
-        RuntimeConfigFile="$(RuntimeConfigFile)"
-        PropertyName="System.Runtime.Serialization.EnableUnsafeBinaryFormatterSerialization"
-        PropertyValue="true"
-        Condition="Exists('$(RuntimeConfigFile)') And '$(DotNet_8_0_OrGreater)' == 'true'" />
-  </Target>
-  
 </Project>

--- a/tests/TestAssemblyInfo.cs
+++ b/tests/TestAssemblyInfo.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 // ICU4N TODO: Some tests are not always completing, so adding this
 // attribute to explictly fail so the mystery test can be investigated.
 #if !DEBUG
-[assembly: Timeout(90000)]
+[assembly: Timeout(120000)]
 #endif
 
 [assembly: SuppressMessage("Microsoft.Design", "CA1034", Justification = "We don't care about Java-style classes in tests")]


### PR DESCRIPTION
Added test support for binary serialization on .NET 8+. Eliminated .NET 8 hack for enabling binary serialization.

This removes a hack that we added to modify the `.runtimeconfig.json` file directly and relies on the official [System.Runtime.Serialization.Formatters](https://www.nuget.org/packages/System.Runtime.Serialization.Formatters) package and `EnableUnsafeBinaryFormatterSerialization` MSBuild property to enable serialization in tests.

This also enables binary serialization APIs on .NET 9+ which ensures these APIs don't break binary compatibility between target frameworks. That is, APIs can be added on later target frameworks, but should not be removed as that could cause issues when the consuming projects multi-target `netstandard2.0` and `net9.0`+.