### PR TITLE
Added support for C# 14.0 (Fixes #120)

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -27,8 +27,9 @@
       net47             | net40
 
     -->
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(VisualStudioVersion)' &gt;= '16.10'">net9.0;net8.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">$(TargetFrameworks);net48;net472;net47</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(IsLegacyVisualStudioVersion)' != 'true'">$(TargetFrameworks);net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And $([MSBuild]::IsOsPlatform('Windows')) And '$(IsLegacyVisualStudioVersion)' != 'true'">$(TargetFrameworks);net48;net472;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>
 
   </PropertyGroup>

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -56,12 +56,20 @@ steps:
     sdkVersion: '$(DotNetSdkVersion)'
     performMultiLevelLookup: '$(PerformMultiLevelLookup)'
 
+- task: UseDotNet@2
+  displayName: 'Use .NET SDK 9.0.313'
+  inputs:
+    packageType: 'sdk'
+    version: '9.0.313'
+    performMultiLevelLookup: '${{ variables.PerformMultiLevelLookup }}'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net9.'))
+
     # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
     # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
     # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
     # This code only works on Windows.
 - pwsh: |
-    $sdkVersion = '$(DotNetSdkVersion)'
+    $sdkVersion = '9.0.313'
     $architecture = '${{ parameters.vsTestPlatform }}'
     $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
     $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
@@ -70,7 +78,7 @@ steps:
     $installPath = "${env:ProgramFiles(x86)}/dotnet"
     & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
     Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
-  displayName: 'Use .NET SDK $(DotNetSdkVersion) (x86)'
+  displayName: 'Use .NET SDK 9.0.313 (x86)'
   condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net9.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
 
 

--- a/.build/runbuild.ps1
+++ b/.build/runbuild.ps1
@@ -19,7 +19,7 @@ properties {
     [string]$configuration         = "Release"
     [string]$platform              = "Any CPU"
     [bool]$backupFiles             = $true
-    [string]$minimumSdkVersion     = "9.0.100"
+    [string]$minimumSdkVersion     = "10.0.100"
 
     #test parameters
     [string]$testPlatforms         = "x64"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,6 +9,15 @@
     <CLSCompliant>true</CLSCompliant>
   </PropertyGroup>
 
+  <PropertyGroup Label="Legacy Visual Studio Support">
+    <VisualStudioMajorVersion>0</VisualStudioMajorVersion>
+    <!-- Extract major version (works for preview builds too) -->
+    <VisualStudioMajorVersion Condition="'$(VisualStudioVersion)' != ''">$([System.Version]::Parse($([System.Text.RegularExpressions.Regex]::Match('$(VisualStudioVersion)', '^\d+(\.\d+)*').Value)).Major)</VisualStudioMajorVersion>
+    <IsLegacyVisualStudioVersion>false</IsLegacyVisualStudioVersion>
+    <!-- Visual Studio 2026 == Version 18.x - anything below that major version is legacy -->
+    <IsLegacyVisualStudioVersion Condition="'$(BuildingInsideVisualStudio)' == 'true' And '$(VisualStudioMajorVersion)' &lt; '18'">true</IsLegacyVisualStudioVersion>
+  </PropertyGroup>
+
   <PropertyGroup Label="Version Settings">
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RepositoryRoot>$(MSBuildThisFileDirectory)</RepositoryRoot>
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>14.0</LangVersion>
     <GitHubOrganization>NightOwl888</GitHubOrganization>
     <GitHubProject>ICU4N</GitHubProject>
     <ArtifactsDir>$(RepositoryRoot)_artifacts</ArtifactsDir>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -69,7 +69,6 @@
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_TOBYTEARRAY_BIGENDIAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CREATE</DefineConstants>
-    <DefineConstants>$(DefineConstants);FEATURE_STRING_IMPLCIT_TO_READONLYSPAN</DefineConstants>
 
   </PropertyGroup>
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ variables:
 - name: TestTargetFrameworks
   value: 'net9.0;net8.0;net6.0;net48;net472;net47'
 - name: DotNetSDKVersion
-  value: '9.0.300'
+  value: '10.0.202'
 - name: BinaryArtifactName
   value: 'testbinaries'
 - name: NuGetArtifactName

--- a/docs/building-and-testing.md
+++ b/docs/building-and-testing.md
@@ -5,7 +5,10 @@
 ### Prerequisites
 
 - [PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/install/installing-powershell) 3.0 or higher (see [this question](http://stackoverflow.com/questions/1825585/determine-installed-powershell-version) to check your PowerShell version)
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
+- [.NET 9 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) (Required only if testing)
+- [.NET 8 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (Required only if testing)
+- [.NET 6 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) (Required only if testing)
 - [.NET Framework 4.6.2 Developer Pack or Higher](https://dotnet.microsoft.com/en-us/download/dotnet-framework)
 
 ### Execution
@@ -87,10 +90,13 @@ Then all you need to do is choose the `ICU4N Local Packages` feed from the dropd
 
 ### Prerequisites
 
-1. Visual Studio 2019 or higher
-2. [.NET 8.0 SDK or higher](https://dotnet.microsoft.com/download/visual-studio-sdks)
+- Visual Studio 2022 or higher
+- [.NET 10.0 SDK](https://dotnet.microsoft.com/download/visual-studio-sdks)
+- [.NET 9 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) (Required only if testing)
+- [.NET 8 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (Required only if testing)
+- [.NET 6 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) (Required only if testing)
 
-> **NOTE:** Preview versions of .NET SDK require the "Use previews of the .NET SDK (requires restart)" option to be enabled in Visual Studio under Tools > Options > Environment > Preview Features. .NET 6.0 is not supported on Visual Studio 2019, so the only option available for building on VS 2019 is to use a pre-release .NET 6.0 SDK.
+> **NOTE:** Visual Studio 2022 is only supported for building and testing .NET Core and .NET Standard 2.1 due to false errors caused by lack of LSP language support for C# 14.0. It is recommended to use Visual Studio 2026, which fully supports our build. If using Visual Studio 2022, we recommend running `dotnet build` on the command line prior to submitting PRs to ensure builds succeed on .NET Framework and .NET Standard 2.0.
 
 ### Execution
 

--- a/docs/make-release.md
+++ b/docs/make-release.md
@@ -4,7 +4,10 @@ This project uses Nerdbank.GitVersioning to assist with creating version numbers
 
 ## Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)
+- [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
+- [.NET 9 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/9.0) (Required only if testing)
+- [.NET 8 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) (Required only if testing)
+- [.NET 6 Runtime (Or SDK)](https://dotnet.microsoft.com/en-us/download/dotnet/6.0) (Required only if testing)
 - [nbgv tool](https://www.nuget.org/packages/nbgv/) (the version must match the one used in the [dependencies.props](.build/dependencies.props) file)
 
 ### Installing NBGV Tool

--- a/src/ICU4N.Collation/ICU4N.Collation.csproj
+++ b/src/ICU4N.Collation/ICU4N.Collation.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.Collation/Impl/Coll/CollationBuilder.cs
+++ b/src/ICU4N.Collation/Impl/Coll/CollationBuilder.cs
@@ -1032,7 +1032,7 @@ namespace ICU4N.Impl.Coll
                     string prefix = prefixIter.Current;
                     if (IgnorePrefix(prefix)) { continue; }
                     bool samePrefix = prefix.ContentEquals(nfdPrefix);
-                    ReadOnlySpan<char> prefixCharSequence = prefix.AsSpan();
+                    ReadOnlySpan<char> prefixCharSequence = prefix;
                     while (stringIter.MoveNext())
                     {
                         string str = stringIter.Current;
@@ -1079,7 +1079,7 @@ namespace ICU4N.Impl.Coll
                 Debug.Assert(iter.Codepoint != UnicodeSetIterator.IsString);
                 int composite = iter.Codepoint;
                 string decomp = nfd.GetDecomposition(composite);
-                if (!MergeCompositeIntoString(nfdString, indexAfterLastStarter, composite, decomp.AsSpan(),
+                if (!MergeCompositeIntoString(nfdString, indexAfterLastStarter, composite, decomp,
                         newNFDString, newString))
                 {
                     continue;
@@ -1217,7 +1217,7 @@ namespace ICU4N.Impl.Coll
             }
             Debug.Assert(nfd.IsNormalized(newNFDString.AsSpan()));
             Debug.Assert(fcd.IsNormalized(newString.AsSpan()));
-            Debug.Assert(nfd.Normalize(newString.AsSpan()).AsSpan().Equals(newNFDString.AsSpan(), StringComparison.Ordinal));  // canonically equivalent
+            Debug.Assert(nfd.Normalize(newString.AsSpan()).Equals(newNFDString.AsSpan(), StringComparison.Ordinal));  // canonically equivalent
             return true;
         }
 

--- a/src/ICU4N.Collation/Impl/Coll/CollationDataBuilder.cs
+++ b/src/ICU4N.Collation/Impl/Coll/CollationDataBuilder.cs
@@ -1276,7 +1276,7 @@ namespace ICU4N.Impl.Coll
                 ConditionalCE32 firstCond = cond;
                 ConditionalCE32 lastCond = cond;
                 while (cond.Next >= 0 &&
-                        (cond = GetConditionalCE32(cond.Next)).Context.AsSpan().StartsWith(prefixSpan, StringComparison.Ordinal))
+                        (cond = GetConditionalCE32(cond.Next)).Context.StartsWith(prefixSpan, StringComparison.Ordinal))
                 {
                     lastCond = cond;
                 }
@@ -1320,7 +1320,7 @@ namespace ICU4N.Impl.Coll
                             if (length == prefixLength) { break; }
                             if (cond.DefaultCE32 != Collation.NO_CE32 &&
                                     (length == 0 || prefixSpan.RegionMatches(
-                                            prefix.Length - length, cond.Context.AsSpan(), 1, length, StringComparison.Ordinal)
+                                            prefix.Length - length, cond.Context, 1, length, StringComparison.Ordinal)
                                             /* C++: prefix.endsWith(cond.context, 1, length) */))
                             {
                                 emptySuffixCE32 = cond.DefaultCE32;

--- a/src/ICU4N.Collation/Impl/Coll/CollationRuleParser.cs
+++ b/src/ICU4N.Collation/Impl/Coll/CollationRuleParser.cs
@@ -371,7 +371,7 @@ namespace ICU4N.Impl.Coll
             }
             try
             {
-                sink.AddRelation(strength, prefix.AsSpan(), rawBuilder.AsMemory(), extension.AsSpan());
+                sink.AddRelation(strength, prefix, rawBuilder.AsMemory(), extension);
             }
             catch (Exception e)
             {
@@ -408,7 +408,7 @@ namespace ICU4N.Impl.Coll
                         try
                         {
                             int length = UTF16.ValueOf(cp, str, 0);
-                            sink.AddRelation(strength, empty.AsSpan(), str.AsMemory(0, length), empty.AsSpan());
+                            sink.AddRelation(strength, empty, str.AsMemory(0, length), empty);
                         }
                         catch (Exception e)
                         {
@@ -460,7 +460,7 @@ namespace ICU4N.Impl.Coll
                         try
                         {
                             int length = UTF16.ValueOf(prev, str, 0);
-                            sink.AddRelation(strength, empty.AsSpan(), str.AsMemory(0, length), empty.AsSpan());
+                            sink.AddRelation(strength, empty, str.AsMemory(0, length), empty);
                         }
                         catch (Exception e)
                         {

--- a/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
+++ b/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
+++ b/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.RegionData/ICU4N.RegionData.csproj
+++ b/src/ICU4N.RegionData/ICU4N.RegionData.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
+++ b/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <CLSCompliant>false</CLSCompliant>
   </PropertyGroup>

--- a/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
+++ b/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->
     <IncludeBuildOutput>false</IncludeBuildOutput>

--- a/src/ICU4N/Globalization/CharSequences.cs
+++ b/src/ICU4N/Globalization/CharSequences.cs
@@ -28,44 +28,6 @@ namespace ICU4N.Globalization
         /// Find the longest n such that a[aIndex,n] = b[bIndex,n], and n is on a character boundary.
         /// </summary>
         [Obsolete("This API is ICU internal only.")]
-        public static int MatchAfter(string a, string b, int aIndex, int bIndex)
-        {
-            if (a is null)
-                throw new ArgumentNullException(nameof(a));
-            if (b is null)
-                throw new ArgumentNullException(nameof(b));
-
-            return MatchAfter(a.AsSpan(), b.AsSpan(), aIndex, bIndex);
-        }
-
-        /// <summary>
-        /// Find the longest n such that a[aIndex,n] = b[bIndex,n], and n is on a character boundary.
-        /// </summary>
-        [Obsolete("This API is ICU internal only.")]
-        public static int MatchAfter(string a, ReadOnlySpan<char> b, int aIndex, int bIndex)
-        {
-            if (a is null)
-                throw new ArgumentNullException(nameof(a));
-
-            return MatchAfter(a.AsSpan(), b, aIndex, bIndex);
-        }
-
-        /// <summary>
-        /// Find the longest n such that a[aIndex,n] = b[bIndex,n], and n is on a character boundary.
-        /// </summary>
-        [Obsolete("This API is ICU internal only.")]
-        public static int MatchAfter(ReadOnlySpan<char> a, string b, int aIndex, int bIndex)
-        {
-            if (b is null)
-                throw new ArgumentNullException(nameof(b));
-
-            return MatchAfter(a, b.AsSpan(), aIndex, bIndex);
-        }
-
-        /// <summary>
-        /// Find the longest n such that a[aIndex,n] = b[bIndex,n], and n is on a character boundary.
-        /// </summary>
-        [Obsolete("This API is ICU internal only.")]
         public static int MatchAfter(ReadOnlySpan<char> a, ReadOnlySpan<char> b, int aIndex, int bIndex)
         {
             int i = aIndex, j = bIndex;

--- a/src/ICU4N/Globalization/UCharacter.cs
+++ b/src/ICU4N/Globalization/UCharacter.cs
@@ -2886,7 +2886,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToUpper(GetDefaultCaseLocale(), 0, str.AsSpan());
+            return CaseMapImpl.ToUpper(GetDefaultCaseLocale(), 0, str);
         }
 
         /// <summary>
@@ -2901,7 +2901,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToLower(GetDefaultCaseLocale(), 0, str.AsSpan());
+            return CaseMapImpl.ToLower(GetDefaultCaseLocale(), 0, str);
         }
 
         /// <summary>
@@ -2966,7 +2966,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToUpper(GetCaseLocale(locale), 0, str.AsSpan());
+            return CaseMapImpl.ToUpper(GetCaseLocale(locale), 0, str);
         }
 
         /// <summary>
@@ -2982,7 +2982,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToUpper(GetCaseLocale(locale), 0, str.AsSpan());
+            return CaseMapImpl.ToUpper(GetCaseLocale(locale), 0, str);
         }
 
         /// <summary>
@@ -2998,7 +2998,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToLower(GetCaseLocale(locale), 0, str.AsSpan());
+            return CaseMapImpl.ToLower(GetCaseLocale(locale), 0, str);
         }
 
         /// <summary>
@@ -3014,7 +3014,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.ToLower(GetCaseLocale(locale), 0, str.AsSpan());
+            return CaseMapImpl.ToLower(GetCaseLocale(locale), 0, str);
         }
 
         /// <summary>
@@ -3107,7 +3107,7 @@ namespace ICU4N
             }
             titleIter = CaseMapImpl.GetTitleBreakIterator(locale!, options, titleIter);
             titleIter.SetText(str);
-            return CaseMapImpl.ToTitle(GetCaseLocale(locale), options, titleIter, str.AsSpan());
+            return CaseMapImpl.ToTitle(GetCaseLocale(locale), options, titleIter, str);
         }
 
         /// <summary>
@@ -3221,7 +3221,7 @@ namespace ICU4N
             }
             titleIter = CaseMapImpl.GetTitleBreakIterator(locale!, options, titleIter);
             titleIter.SetText(str);
-            return CaseMapImpl.ToTitle(GetCaseLocale(locale), options, titleIter, str.AsSpan());
+            return CaseMapImpl.ToTitle(GetCaseLocale(locale), options, titleIter, str);
         }
 
 #nullable restore
@@ -3358,7 +3358,7 @@ namespace ICU4N
             if (str is null)
                 throw new ArgumentNullException(nameof(str));
 
-            return CaseMapImpl.Fold((int)foldCase, str.AsSpan());
+            return CaseMapImpl.Fold((int)foldCase, str);
         }
 
         /// <icu/>

--- a/src/ICU4N/ICU4N.csproj
+++ b/src/ICU4N/ICU4N.csproj
@@ -4,8 +4,8 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks Condition="$(VisualStudioVersion) &gt;= 16.10">net9.0;net8.0</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
+    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     
@@ -105,8 +105,7 @@
 
   <PropertyGroup>
     <ICU4JResourceConverterDir>$(SolutionDir)src/tools/ICU4JResourceConverter</ICU4JResourceConverterDir>
-    <ICU4JResourceConverterTargetFramework>net5.0</ICU4JResourceConverterTargetFramework>
-    <ICU4JResourceConverterTargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net9.0</ICU4JResourceConverterTargetFramework>
+    <ICU4JResourceConverterTargetFramework>net10.0</ICU4JResourceConverterTargetFramework>
     <ICU4JResourceConverterOutputDir>$(ICU4JResourceConverterDir)/bin/$(Configuration)/$(ICU4JResourceConverterTargetFramework)</ICU4JResourceConverterOutputDir>
 
     <ICU4JDownloadConfigFilePath>$(SolutionDir).build/icu4j-download-urls.txt</ICU4JDownloadConfigFilePath>

--- a/src/ICU4N/Impl/BMPSet.cs
+++ b/src/ICU4N/Impl/BMPSet.cs
@@ -146,29 +146,6 @@ namespace ICU4N.Impl
         /// sufficient length for trail unit for each surrogate pair. Handle single surrogates as surrogate code points
         /// as usual in ICU.
         /// </remarks>
-        public int Span(string s, int start, SpanCondition spanCondition,
-            out int outCount)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return Span(s.AsSpan(), start, spanCondition, out outCount);
-        }
-
-        /// <summary>
-        /// Span the initial substring for which each character c has <paramref name="spanCondition"/>==Contains(c). 
-        /// It must be <paramref name="spanCondition"/>==0 or 1.
-        /// </summary>
-        /// <param name="s"></param>
-        /// <param name="start">The start index.</param>
-        /// <param name="spanCondition"></param>
-        /// <param name="outCount">If not null: Receives the number of code points in the span.</param>
-        /// <returns>The limit (exclusive end) of the span.</returns>
-        /// <remarks>
-        /// NOTE: to reduce the overhead of function call to Contains(c), it is manually inlined here. Check for
-        /// sufficient length for trail unit for each surrogate pair. Handle single surrogates as surrogate code points
-        /// as usual in ICU.
-        /// </remarks>
         public int Span(ReadOnlySpan<char> s, int start, SpanCondition spanCondition,
             out int outCount) // ICU4N TODO: API - does it make sense to return length instead of limit to match .NET APIs?
         {
@@ -293,20 +270,6 @@ namespace ICU4N.Impl
             int spanLength = i - start;
             outCount = spanLength - numSupplementary;  // number of code points
             return i;
-        }
-
-        /// <summary>
-        /// Symmetrical with <see cref="Span(string, int, SpanCondition, out int)"/>.
-        /// Span the trailing substring for which each character c has <paramref name="spanCondition"/>==Contains(c). 
-        /// It must be <paramref name="s"/>.Length >= limit and <paramref name="spanCondition"/>==0 or 1.
-        /// </summary>
-        /// <returns>The string index which starts the span (i.e. inclusive).</returns>
-        public int SpanBack(string s, int limit, SpanCondition spanCondition) // ICU4N TODO: API - Change limit to length
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return SpanBack(s.AsSpan(), limit, spanCondition);
         }
 
         /// <summary>

--- a/src/ICU4N/Impl/ICUBinary.cs
+++ b/src/ICU4N/Impl/ICUBinary.cs
@@ -126,7 +126,7 @@ namespace ICU4N.Impl
             internal static void AddBaseNamesInFolder(ByteBuffer bytes, string folder, string suffix, ISet<string> names)
             {
                 // Find the first data item name that starts with the folder name.
-                int index = BinarySearch(bytes, folder.AsSpan());
+                int index = BinarySearch(bytes, folder);
                 if (index < 0)
                 {
                     index = ~index;  // Normal: Otherwise the folder itself is the name of a data item.
@@ -330,7 +330,7 @@ namespace ICU4N.Impl
 
             internal override ByteBuffer GetData(string requestedPath)
             {
-                return DatPackageReader.GetData(pkgBytes, requestedPath.AsSpan());
+                return DatPackageReader.GetData(pkgBytes, requestedPath);
             }
 
             internal override void AddBaseNamesInFolder(string folder, string suffix, ISet<string> names)

--- a/src/ICU4N/Impl/ICUData.cs
+++ b/src/ICU4N/Impl/ICUData.cs
@@ -140,7 +140,7 @@ namespace ICU4N.Impl
         internal static Stream GetStream(Assembly loader, string localeID, string resourceName, bool required)
         {
             // ICU4N: Map the locale to a valid .NET culture name so .NET doesn't complain about it being incompatible.
-            string cultureName = ResourceUtil.GetDotNetNeutralCultureName(localeID.AsSpan());
+            string cultureName = ResourceUtil.GetDotNetNeutralCultureName(localeID);
 
             Stream i = null;
             Assembly satelliteAssembly;

--- a/src/ICU4N/Impl/ICUResourceBundle.cs
+++ b/src/ICU4N/Impl/ICUResourceBundle.cs
@@ -813,7 +813,7 @@ namespace ICU4N.Impl
 
             foreach (var file in new DirectoryInfo(PlatformDetection.BaseDirectory).GetFiles(satelliteAssemblyDLLName, SearchOption.AllDirectories))
             {
-                if (LooksLikeACultureName(file.Directory.Name.AsSpan()))
+                if (LooksLikeACultureName(file.Directory.Name))
                 {
 #if FEATURE_SYSTEM_REFLECTION_METADATA
                     AddLocaleIDsFromAssemblyPath(file.FullName, baseName, set);
@@ -868,7 +868,7 @@ namespace ICU4N.Impl
         private static void AddLocaleIDsFromAssemblyPath(string assemblyPath, string baseName, ISet<string> set)
         {
             var prefix = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
-            AppendFilePrefixFromBaseName(baseName.AsSpan(), ref prefix);
+            AppendFilePrefixFromBaseName(baseName, ref prefix);
 
             using var stream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             using var peReader = new PEReader(stream);
@@ -877,9 +877,9 @@ namespace ICU4N.Impl
             foreach (var resourceHandle in reader.ManifestResources)
             {
                 var resource = reader.GetManifestResource(resourceHandle);
-                var name = reader.GetString(resource.Name).AsSpan();
+                var name = reader.GetString(resource.Name);
 
-                if (IsMatchingLocaleFile(name, prefix.AsSpan(), ".res".AsSpan(), out ReadOnlySpan<char> locale))
+                if (IsMatchingLocaleFile(name, prefix.AsSpan(), ".res", out ReadOnlySpan<char> locale))
                     set.Add(locale.ToString());
             }
         }
@@ -887,12 +887,12 @@ namespace ICU4N.Impl
         private static void AppendLocaleIDsFromAssembly(Assembly assembly, string baseName, ISet<string> set)
         {
             var prefix = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
-            AppendFilePrefixFromBaseName(baseName.AsSpan(), ref prefix);
+            AppendFilePrefixFromBaseName(baseName, ref prefix);
 
             // Iterate through embedded resources
             foreach (string resourceName in assembly.GetManifestResourceNames())
             {
-                if (IsMatchingLocaleFile(resourceName.AsSpan(), prefix.AsSpan(), ".res".AsSpan(), out ReadOnlySpan<char> locale))
+                if (IsMatchingLocaleFile(resourceName, prefix.AsSpan(), ".res", out ReadOnlySpan<char> locale))
                     set.Add(locale.ToString());
             }
         }

--- a/src/ICU4N/Impl/ICUResourceBundleImpl.cs
+++ b/src/ICU4N/Impl/ICUResourceBundleImpl.cs
@@ -245,7 +245,7 @@ namespace ICU4N.Impl
             protected override UResourceBundle HandleGet(string resKey, IDictionary<string, string> aliasesVisited,
                                                 UResourceBundle requested)
             {
-                int i = ((ICUResourceBundleReader.Table)value).FindTableItem(wholeBundle.reader, resKey.AsSpan());
+                int i = ((ICUResourceBundleReader.Table)value).FindTableItem(wholeBundle.reader, resKey);
                 if (i < 0)
                 {
                     return null;
@@ -271,7 +271,7 @@ namespace ICU4N.Impl
                 // so that we know the expected object type,
                 // but those are final in java.util.ResourceBundle.
                 ICUResourceBundleReader reader = wholeBundle.reader;
-                int index = ((ICUResourceBundleReader.Table)value).FindTableItem(reader, key.AsSpan());
+                int index = ((ICUResourceBundleReader.Table)value).FindTableItem(reader, key);
                 if (index >= 0)
                 {
                     int res = value.GetContainerResource(reader, index);
@@ -313,7 +313,7 @@ namespace ICU4N.Impl
             internal virtual string FindString(string key)
             {
                 ICUResourceBundleReader reader = wholeBundle.reader;
-                int index = ((ICUResourceBundleReader.Table)value).FindTableItem(reader, key.AsSpan());
+                int index = ((ICUResourceBundleReader.Table)value).FindTableItem(reader, key);
                 if (index < 0)
                 {
                     return null;

--- a/src/ICU4N/Impl/ICUResourceBundleReader.cs
+++ b/src/ICU4N/Impl/ICUResourceBundleReader.cs
@@ -1288,7 +1288,7 @@ namespace ICU4N.Impl
 
             internal override int GetResource(ICUResourceBundleReader reader, string resKey)
             {
-                return GetContainerResource(reader, FindTableItem(reader, resKey.AsSpan()));
+                return GetContainerResource(reader, FindTableItem(reader, resKey));
             }
 
             public virtual bool GetKeyAndValue(int i, ResourceKey key, ResourceValue value)

--- a/src/ICU4N/Impl/Locale/AsciiCaseInsensitiveKey.cs
+++ b/src/ICU4N/Impl/Locale/AsciiCaseInsensitiveKey.cs
@@ -15,12 +15,12 @@ namespace ICU4N.Impl.Locale
         public AsciiCaseInsensitiveKey(string value)
         {
             this.value = value;
-            hashCode = AsciiUtil.GetHashCodeOrdinalIgnoreCase(value.AsSpan());
+            hashCode = AsciiUtil.GetHashCodeOrdinalIgnoreCase(value);
         }
 
         public bool Equals(ReadOnlySpan<char> other)
         {
-            return AsciiUtil.CaseIgnoreMatch(value.AsSpan(), other);
+            return AsciiUtil.CaseIgnoreMatch(value, other);
         }
 
         public bool Equals(string other)

--- a/src/ICU4N/Impl/Locale/AsciiUtil.cs
+++ b/src/ICU4N/Impl/Locale/AsciiUtil.cs
@@ -351,14 +351,6 @@ namespace ICU4N.Impl.Locale
             return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsAlpha(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            return IsAlpha(s.AsSpan());
-        }
-
         public static bool IsAlpha(ReadOnlySpan<char> s) // ICU4N specific - renamed from ToAlphaString()
         {
             bool b = true;
@@ -379,13 +371,6 @@ namespace ICU4N.Impl.Locale
             return (c >= '0' && c <= '9');
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsNumeric(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            return IsNumeric(s.AsSpan());
-        }
         public static bool IsNumeric(ReadOnlySpan<char> s) // ICU4N specific - renamed from IsNumericString()
         {
             bool b = true;
@@ -404,14 +389,6 @@ namespace ICU4N.Impl.Locale
         public static bool IsAlphaNumeric(char c)
         {
             return IsAlpha(c) || IsNumeric(c);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsAlphaNumeric(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            return IsAlphaNumeric(s.AsSpan());
         }
 
         public static bool IsAlphaNumeric(ReadOnlySpan<char> s) // ICU4N specific - renamed from IsAlphaNumericString()

--- a/src/ICU4N/Impl/Locale/Extension.cs
+++ b/src/ICU4N/Impl/Locale/Extension.cs
@@ -35,7 +35,7 @@ namespace ICU4N.Impl.Locale
         }
 
         public virtual string ID => LazyInitializer.EnsureInitialized(ref id,
-            () => StringHelper.Concat(stackalloc char[] { key, LanguageTag.Separator }, value.AsSpan()))!;
+            () => StringHelper.Concat(stackalloc char[] { key, LanguageTag.Separator }, value))!;
 
         public override string ToString()
         {

--- a/src/ICU4N/Impl/Locale/InternalLocaleBuilder.cs
+++ b/src/ICU4N/Impl/Locale/InternalLocaleBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using ICU4N.Support.Collections;
+using ICU4N.Support.Text;
 using ICU4N.Text;
 using System;
 using System.Buffers;
@@ -150,7 +151,7 @@ namespace ICU4N.Impl.Locale
                     // normalize separator to "-"
                     string tp = type.Replace(BaseLocale.Separator, LanguageTag.Separator);
                     // validate
-                    StringTokenEnumerator itr = new StringTokenEnumerator(tp.AsSpan(), LanguageTag.Separator);
+                    StringTokenEnumerator itr = new StringTokenEnumerator(tp, LanguageTag.Separator);
                     while (itr.MoveNext())
                     {
                         ReadOnlySpan<char> s = itr.Current;
@@ -212,7 +213,7 @@ namespace ICU4N.Impl.Locale
                 try
                 {
                     Span<char> val = usePool ? pooledArray.AsSpan(valueLength) : stackalloc char[valueLength];
-                    value.AsSpan().CopyTo(val);
+                    value.CopyTo(val);
                     val.Replace(BaseLocale.Separator, LanguageTag.Separator);
 
                     StringTokenEnumerator itr = new StringTokenEnumerator(val, LanguageTag.Separator);
@@ -266,7 +267,7 @@ namespace ICU4N.Impl.Locale
                 return this;
             }
             subtags = subtags.Replace(BaseLocale.Separator, LanguageTag.Separator);
-            StringTokenEnumerator itr = new StringTokenEnumerator(subtags.AsSpan(), LanguageTag.Separator);
+            StringTokenEnumerator itr = new StringTokenEnumerator(subtags, LanguageTag.Separator);
 
             List<string>? extensions = null;
             string? privateuse = null;
@@ -615,7 +616,7 @@ namespace ICU4N.Impl.Locale
             {
                 if (_extensions.TryGetValue(PRIVUSE_KEY, out string? privuse) && privuse != null)
                 {
-                    StringTokenEnumerator itr = new StringTokenEnumerator(privuse.AsSpan(), LanguageTag.Separator);
+                    StringTokenEnumerator itr = new StringTokenEnumerator(privuse, LanguageTag.Separator);
                     bool sawPrefix = false;
                     int privVarStart = -1;
                     while (itr.MoveNext())
@@ -625,7 +626,7 @@ namespace ICU4N.Impl.Locale
                             privVarStart = itr.Current.StartIndex;
                             break;
                         }
-                        if (AsciiUtil.CaseIgnoreMatch(itr.Current, LanguageTag.PrivateUse_Variant_Prefix.AsSpan()))
+                        if (AsciiUtil.CaseIgnoreMatch(itr.Current, LanguageTag.PrivateUse_Variant_Prefix))
                         {
                             sawPrefix = true;
                         }
@@ -674,7 +675,7 @@ namespace ICU4N.Impl.Locale
         /// </summary>
         internal static string? RemovePrivateuseVariant(string? privuseVal)
         {
-            StringTokenEnumerator itr = new StringTokenEnumerator(privuseVal.AsSpan(), LanguageTag.Separator);
+            StringTokenEnumerator itr = new StringTokenEnumerator(privuseVal, LanguageTag.Separator);
 
             // Note: privateuse value "abc-lvariant" is unchanged
             // because no subtags after "lvariant".
@@ -691,7 +692,7 @@ namespace ICU4N.Impl.Locale
                     sawPrivuseVar = true;
                     break;
                 }
-                if (AsciiUtil.CaseIgnoreMatch(itr.Current, LanguageTag.PrivateUse_Variant_Prefix.AsSpan()))
+                if (AsciiUtil.CaseIgnoreMatch(itr.Current, LanguageTag.PrivateUse_Variant_Prefix))
                 {
                     prefixStart = itr.Current.StartIndex;
                 }
@@ -711,7 +712,7 @@ namespace ICU4N.Impl.Locale
         /// </summary>
         private int CheckVariants(string variants, char sep)
         {
-            StringTokenEnumerator itr = new StringTokenEnumerator(variants.AsSpan(), sep);
+            StringTokenEnumerator itr = new StringTokenEnumerator(variants, sep);
             while (itr.MoveNext())
             {
                 ReadOnlySpan<char> s = itr.Current;

--- a/src/ICU4N/Impl/Locale/LanguageTag.cs
+++ b/src/ICU4N/Impl/Locale/LanguageTag.cs
@@ -1,4 +1,5 @@
 ﻿using ICU4N.Support.Collections;
+using ICU4N.Support.Text;
 using ICU4N.Text;
 using J2N.Collections.Generic.Extensions;
 using System;
@@ -169,7 +170,7 @@ namespace ICU4N.Impl.Locale
             if (Grandfathered.TryGetValue(languageTag, out string? gf))
             {
                 // use preferred mapping
-                itr = new StringTokenEnumerator(gf.AsSpan(), Separator);
+                itr = new StringTokenEnumerator(gf, Separator);
                 isGrandfathered = true;
             }
             else
@@ -475,7 +476,7 @@ namespace ICU4N.Impl.Locale
             string language = baseLocale.Language;
             string script = baseLocale.Script;
             string region = baseLocale.Region;
-            ReadOnlySpan<char> variant = baseLocale.Variant.AsSpan();
+            string variant = baseLocale.Variant;
 
             bool hasSubtag = false;
 
@@ -639,7 +640,7 @@ namespace ICU4N.Impl.Locale
                     }
                     concatBuffer[0] = locextKey;
                     concatBuffer[1] = Separator;
-                    extensions.Add(StringHelper.Concat(concatBuffer, ext.Value.AsSpan()));
+                    extensions.Add(StringHelper.Concat(concatBuffer, ext.Value));
                 }
             }
 
@@ -674,7 +675,7 @@ namespace ICU4N.Impl.Locale
                         sb.Append(PrivateUse_Variant_Prefix);
                         sb.Append(Separator);
                         var privuse = sb.AppendSpan(privuseVar.Length);
-                        privuseVar.AsSpan().CopyTo(privuse);
+                        privuseVar.CopyTo(privuse);
                         privuse.Replace(BaseLocale.Separator, Separator);
                     }
                     privateuse = sb.ToString();
@@ -739,19 +740,6 @@ namespace ICU4N.Impl.Locale
         //
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsLanguage(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            // language      = 2*3ALPHA            ; shortest ISO 639 code
-            //                 ["-" extlang]       ; sometimes followed by
-            //                                     ;   extended language subtags
-            //               / 4ALPHA              ; or reserved for future use
-            //               / 5*8ALPHA            ; or registered language subtag
-            return (s.Length >= 2) && (s.Length <= 8) && AsciiUtil.IsAlpha(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLanguage(ReadOnlySpan<char> s)
         {
             // language      = 2*3ALPHA            ; shortest ISO 639 code
@@ -763,30 +751,11 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsExtlang(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            // extlang       = 3ALPHA              ; selected ISO 639 codes
-            //                 *2("-" 3ALPHA)      ; permanently reserved
-            return (s.Length == 3) && AsciiUtil.IsAlpha(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsExtlang(ReadOnlySpan<char> s)
         {
             // extlang       = 3ALPHA              ; selected ISO 639 codes
             //                 *2("-" 3ALPHA)      ; permanently reserved
             return (s.Length == 3) && AsciiUtil.IsAlpha(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsScript(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            // script        = 4ALPHA              ; ISO 15924 code
-            return (s.Length == 4) && AsciiUtil.IsAlpha(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -797,31 +766,12 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsRegion(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            // region        = 2ALPHA              ; ISO 3166-1 code
-            //               / 3DIGIT              ; UN M.49 code
-            return ((s.Length == 2) && AsciiUtil.IsAlpha(s))
-                    || ((s.Length == 3) && AsciiUtil.IsNumeric(s));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsRegion(ReadOnlySpan<char> s)
         {
             // region        = 2ALPHA              ; ISO 3166-1 code
             //               / 3DIGIT              ; UN M.49 code
             return ((s.Length == 2) && AsciiUtil.IsAlpha(s))
                     || ((s.Length == 3) && AsciiUtil.IsNumeric(s));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsVariant(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-            return IsVariant(s.AsSpan());
         }
 
         public static bool IsVariant(ReadOnlySpan<char> s)
@@ -844,11 +794,8 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsExtensionSingleton(string s)
+        public static bool IsExtensionSingleton(ReadOnlySpan<char> s)
         {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
             // singleton     = DIGIT               ; 0 - 9
             //               / %x41-57             ; A - W
             //               / %x59-5A             ; Y - Z
@@ -861,33 +808,9 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsExtensionSingleton(ReadOnlySpan<char> s)
-        {
-            // singleton     = DIGIT               ; 0 - 9
-            //               / %x41-57             ; A - W
-            //               / %x59-5A             ; Y - Z
-            //               / %x61-77             ; a - w
-            //               / %x79-7A             ; y - z
-
-            return (s.Length == 1)
-                    && AsciiUtil.IsAlpha(s)
-                    && !AsciiUtil.CaseIgnoreMatch(Private_Use.AsSpan(), s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsExtensionSingletonChar(char c)
         {
             return IsExtensionSingleton(stackalloc char[1] { c });
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsExtensionSubtag(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            // extension     = singleton 1*("-" (2*8alphanum))
-            return (s.Length >= 2) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -898,39 +821,18 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPrivateusePrefix(string s)
+        public static bool IsPrivateusePrefix(ReadOnlySpan<char> s)
         {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
             // privateuse    = "x" 1*("-" (1*8alphanum))
             return (s.Length == 1)
                     && AsciiUtil.CaseIgnoreMatch(Private_Use, s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPrivateusePrefix(ReadOnlySpan<char> s)
-        {
-            // privateuse    = "x" 1*("-" (1*8alphanum))
-            return (s.Length == 1)
-                    && AsciiUtil.CaseIgnoreMatch(Private_Use.AsSpan(), s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsPrivateusePrefixChar(char c)
         {
             Span<char> buffer = stackalloc char[1] { c };
-            return (AsciiUtil.CaseIgnoreMatch(Private_Use.AsSpan(), buffer));
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsPrivateuseSubtag(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            // privateuse    = "x" 1*("-" (1*8alphanum))
-            return (s.Length >= 1) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+            return (AsciiUtil.CaseIgnoreMatch(Private_Use, buffer));
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ICU4N/Impl/Locale/UnicodeLocaleExtension.cs
+++ b/src/ICU4N/Impl/Locale/UnicodeLocaleExtension.cs
@@ -120,24 +120,10 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsAttribute(string s)
-        {
-            // 3*8alphanum
-            return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsAttribute(ReadOnlySpan<char> s)
         {
             // 3*8alphanum
             return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsKey(string s)
-        {
-            // 2alphanum
-            return (s.Length == 2) && AsciiUtil.IsAlphaNumeric(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -148,23 +134,10 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsTypeSubtag(string s)
-        {
-            // 3*8alphanum
-            return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsTypeSubtag(ReadOnlySpan<char> s)
         {
             // 3*8alphanum
             return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
-        }
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool IsType(string s)
-        {
-            return IsType(s.AsSpan());
         }
 
         public static bool IsType(ReadOnlySpan<char> s)

--- a/src/ICU4N/Impl/LocaleIDParser.cs
+++ b/src/ICU4N/Impl/LocaleIDParser.cs
@@ -48,18 +48,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         private const char DOT = '.';
         private const char UNDERSCORE = '_';
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        public LocaleIDParser(Span<char> initialBuffer, string localeID)
-            : this(initialBuffer, localeID.AsSpan(), false)
-        {
-        }
-
-        public LocaleIDParser(Span<char> initialBuffer, string localeID, bool canonicalize)
-            : this(initialBuffer, localeID.AsSpan(), canonicalize)
-        {
-        }
-#endif
-
         public LocaleIDParser(Span<char> initialBuffer, ReadOnlySpan<char> localeID)
             : this(initialBuffer, localeID, false)
         {
@@ -75,16 +63,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             this.keywords = null;
             this.baseName = ReadOnlySpan<char>.Empty;
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Reset(string localeID)
-            => Reset(localeID.AsSpan());
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void Reset(string localeID, bool canonicalize)
-            => Reset(localeID.AsSpan(), canonicalize);
-#endif
 
         public void Reset(ReadOnlySpan<char> localeID)
         {
@@ -134,15 +112,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             return buffer.AsSpan(start);
         }
 
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Set the length of the buffer to pos, then append the string.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void Set(int pos, string s)
-            => Set(pos, s.AsSpan());
-#endif
         /// <summary>
         /// Set the length of the buffer to pos, then append the string.
         /// </summary>
@@ -755,12 +724,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                 variant: GetString(ParseVariant())
             );
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-
-        public void SetBaseName(string baseName)
-            => SetBaseName(baseName.AsSpan());
-#endif
 
         public void SetBaseName(ReadOnlySpan<char> baseName)
         {

--- a/src/ICU4N/Impl/LocaleIDs.cs
+++ b/src/ICU4N/Impl/LocaleIDs.cs
@@ -37,20 +37,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             return (string[])_languages.Clone();
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Returns a three-letter abbreviation for the provided country.  If the provided
-        /// country is empty, returns the empty string.  Otherwise, returns
-        /// an uppercase ISO 3166 3-letter country code.
-        /// </summary>
-        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
-        /// three-letter country abbreviation is not available for this locale.</exception>
-        /// <stable>ICU 3.0</stable>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string GetThreeLetterISOCountryName(string country)
-            => GetThreeLetterISOCountryName(country.AsSpan());
-#endif
-
         /// <summary>
         /// Returns a three-letter abbreviation for the provided country.  If the provided
         /// country is empty, returns the empty string.  Otherwise, returns
@@ -76,23 +62,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             }
             return "";
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Returns a three-letter abbreviation for the language.  If language is
-        /// empty, returns the empty string.  Otherwise, returns
-        /// a lowercase ISO 639-2/T language code.
-        /// </summary>
-        /// <remarks>The ISO 639-2 language codes can be found on-line at
-        /// <a href="ftp://dkuug.dk/i18n/iso-639-2.txt">ftp://dkuug.dk/i18n/iso-639-2.txt</a>.
-        /// </remarks>
-        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
-        /// three-letter language abbreviation is not available for this locale.</exception>
-        /// <stable>ICU 3.0</stable>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string GetThreeLetterISOLanguageName(string language)
-            => GetThreeLetterISOLanguageName(language.AsSpan());
-#endif
 
         /// <summary>
         /// Returns a three-letter abbreviation for the language.  If language is
@@ -123,12 +92,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             return "";
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ThreeToTwoLetterLanguage(string lang)
-            => ThreeToTwoLetterLanguage(lang.AsSpan());
-#endif
-
         public static string ThreeToTwoLetterLanguage(ReadOnlySpan<char> lang)
         {
             /* convert 3 character code to 2 character code if possible *CWB*/
@@ -146,12 +109,6 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
 
             return null;
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static string ThreeToTwoLetterRegion(string region)
-            => ThreeToTwoLetterRegion(region.AsSpan());
-#endif
 
         public static string ThreeToTwoLetterRegion(ReadOnlySpan<char> region)
         {
@@ -506,11 +463,15 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             "ANT", "BUR", "SCG", "FXX", "ROM", "SUN", "TMP", "YMD", "YUG", "ZAR",
         };
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string GetCurrentCountryID(string oldID)
-            => GetCurrentCountryID(oldID.AsSpan());
-#endif
+        {
+            int offset = FindIndex(_deprecatedCountries, oldID);
+            if (offset >= 0)
+            {
+                return _replacementCountries[offset];
+            }
+            return oldID;
+        }
 
         public static string GetCurrentCountryID(ReadOnlySpan<char> oldID)
         {
@@ -522,11 +483,15 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             return oldID.ToString();
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string GetCurrentLanguageID(string oldID)
-            => GetCurrentLanguageID(oldID.AsSpan());
-#endif
+        {
+            int offset = FindIndex(_obsoleteLanguages, oldID);
+            if (offset >= 0)
+            {
+                return _replacementLanguages[offset];
+            }
+            return oldID;
+        }
 
         public static string GetCurrentLanguageID(ReadOnlySpan<char> oldID)
         {

--- a/src/ICU4N/Impl/Norm2AllModes.cs
+++ b/src/ICU4N/Impl/Norm2AllModes.cs
@@ -508,7 +508,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.Decompose(src.AsSpan(), ref buffer); // ICU4N: Checked 3rd parameter
+            Impl.Decompose(src, ref buffer); // ICU4N: Checked 3rd parameter
         }
 
         protected override void Normalize(ReadOnlySpan<char> src, ref ReorderingBuffer buffer)
@@ -529,7 +529,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.DecomposeAndAppend(src.AsSpan(), doNormalize, ref buffer);
+            Impl.DecomposeAndAppend(src, doNormalize, ref buffer);
         }
 
         protected override void NormalizeAndAppend(ReadOnlySpan<char> src, bool doNormalize, ref ReorderingBuffer buffer)
@@ -579,7 +579,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.Compose(src.AsSpan(), onlyContiguous, doCompose: true, ref buffer);
+            Impl.Compose(src, onlyContiguous, doCompose: true, ref buffer);
         }
 
         protected override void Normalize(ReadOnlySpan<char> src, ref ReorderingBuffer buffer)
@@ -603,7 +603,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.ComposeAndAppend(src.AsSpan(), doNormalize, onlyContiguous, ref buffer);
+            Impl.ComposeAndAppend(src, doNormalize, onlyContiguous, ref buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -701,7 +701,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.MakeFCD(src.AsSpan(), ref buffer);
+            Impl.MakeFCD(src, ref buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -726,7 +726,7 @@ namespace ICU4N.Impl
             if (src is null)
                 throw new ArgumentNullException(nameof(src));
 
-            Impl.MakeFCDAndAppend(src.AsSpan(), doNormalize, ref buffer);
+            Impl.MakeFCDAndAppend(src, doNormalize, ref buffer);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ICU4N/Impl/Normalizer2Impl.cs
+++ b/src/ICU4N/Impl/Normalizer2Impl.cs
@@ -796,48 +796,6 @@ namespace ICU4N.Impl
         public static bool IsSurrogateLead(int c) { return (c & 0x400) == 0; }
 
         #region Equal(ICharSequence, ICharSequence)
-        /// <summary>
-        /// Compares two character sequence objects for binary equality.
-        /// </summary>
-        /// <param name="s1">s1 first sequence</param>
-        /// <param name="s2">s2 second sequence</param>
-        /// <returns>true if s1 contains the same text as s2.</returns>
-        public static bool Equal(string s1, string s2)
-        {
-            if (s1 == s2)
-            {
-                return true;
-            }
-            if (s1 is null || s2 is null) return false;
-            // ICU4N: Use optimized equality comparison in System.Memory
-            return System.MemoryExtensions.Equals(s1.AsSpan(), s2.AsSpan(), StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Compares two character sequence objects for binary equality.
-        /// </summary>
-        /// <param name="s1">s1 first sequence</param>
-        /// <param name="s2">s2 second sequence</param>
-        /// <returns>true if s1 contains the same text as s2.</returns>
-        public static bool Equal(string s1, ReadOnlySpan<char> s2)
-        {
-            if (s1 is null) return false;
-            // ICU4N: Use optimized equality comparison in System.Memory
-            return System.MemoryExtensions.Equals(s1.AsSpan(), s2, StringComparison.Ordinal);
-        }
-
-        /// <summary>
-        /// Compares two character sequence objects for binary equality.
-        /// </summary>
-        /// <param name="s1">s1 first sequence</param>
-        /// <param name="s2">s2 second sequence</param>
-        /// <returns>true if s1 contains the same text as s2.</returns>
-        public static bool Equal(ReadOnlySpan<char> s1, string s2)
-        {
-            if (s2 is null) return false;
-            // ICU4N: Use optimized equality comparison in System.Memory
-            return System.MemoryExtensions.Equals(s1, s2.AsSpan(), StringComparison.Ordinal);
-        }
 
         /// <summary>
         /// Compares two character sequence objects for binary equality.

--- a/src/ICU4N/Impl/Number/LongNameHandler.cs
+++ b/src/ICU4N/Impl/Number/LongNameHandler.cs
@@ -156,7 +156,7 @@ namespace ICU4N.Numerics
                         // There should always be data in the "other" plural variant.
                         throw new ICUException("Could not find data in 'other' plural variant with field " + field);
                     }
-                    SimpleFormatterImpl.CompileToStringMinMaxArguments(simpleFormat.AsSpan(), ref sb, 1, 1);
+                    SimpleFormatterImpl.CompileToStringMinMaxArguments(simpleFormat, ref sb, 1, 1);
                     string compiled = sb.AsSpan().ToString();
                     output[plural] = new SimpleModifier(compiled, null, false);
                 }

--- a/src/ICU4N/Impl/Number/SimpleModifier.cs
+++ b/src/ICU4N/Impl/Number/SimpleModifier.cs
@@ -30,7 +30,7 @@ namespace ICU4N.Numerics
             this.compiledPattern = compiledPattern ?? throw new ArgumentNullException(nameof(compiledPattern));
             this.field = field;
             this.strong = strong;
-            Debug.Assert(SimpleFormatterImpl.GetArgumentLimit(compiledPattern.AsSpan()) == 1);
+            Debug.Assert(SimpleFormatterImpl.GetArgumentLimit(compiledPattern) == 1);
             if (compiledPattern[1] != '\u0000')
             {
                 prefixLength = compiledPattern[1] - ARG_NUM_LIMIT;

--- a/src/ICU4N/Impl/RuleCharacterIterator.cs
+++ b/src/ICU4N/Impl/RuleCharacterIterator.cs
@@ -350,7 +350,7 @@ namespace ICU4N.Impl
         {
             if (buf != null)
             {
-                return UTF16.CharAt(buf.AsSpan(), bufPos);
+                return UTF16.CharAt(buf, bufPos);
             }
             else
             {

--- a/src/ICU4N/Impl/StandardPlural.cs
+++ b/src/ICU4N/Impl/StandardPlural.cs
@@ -240,36 +240,36 @@ namespace ICU4N.Impl
             switch (keyword.Length)
             {
                 case 3:
-                    if ("one".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    if ("one".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.One;
                         return true;
                     }
-                    else if ("two".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    else if ("two".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.Two;
                         return true;
                     }
-                    else if ("few".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    else if ("few".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.Few;
                         return true;
                     }
                     break;
                 case 4:
-                    if ("many".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    if ("many".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.Many;
                         return true;
                     }
-                    else if ("zero".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    else if ("zero".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.Zero;
                         return true;
                     }
                     break;
                 case 5:
-                    if ("other".AsSpan().Equals(keyword, StringComparison.Ordinal))
+                    if ("other".Equals(keyword, StringComparison.Ordinal))
                     {
                         result = StandardPlural.Other;
                         return true;

--- a/src/ICU4N/Impl/TextTrieMap.cs
+++ b/src/ICU4N/Impl/TextTrieMap.cs
@@ -51,42 +51,11 @@ namespace ICU4N.Impl
         /// <param name="text">The text.</param>
         /// <param name="value">The value associated with the text.</param>
         /// <returns></returns>
-        public virtual TextTrieMap<TValue> Put(string text, TValue value)
-        {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
-            return Put(text.AsSpan(), value);
-        }
-
-        /// <summary>
-        /// Adds the text key and its associated value in this object.
-        /// </summary>
-        /// <param name="text">The text.</param>
-        /// <param name="value">The value associated with the text.</param>
-        /// <returns></returns>
         public virtual TextTrieMap<TValue> Put(ReadOnlySpan<char> text, TValue value)
         {
             CharEnumerator chitr = new CharEnumerator(text, ignoreCase);
             root.Add(chitr, value);
             return this;
-        }
-
-        /// <summary>
-        /// Gets an enumerator of the values associated with the
-        /// longest prefix matching string key.
-        /// </summary>
-        /// <param name="text">The text to be matched with prefixes.</param>
-        /// <returns>
-        /// An enumerator of the values associated with
-        /// the longest prefix matching matching key, or <c>null</c>
-        /// if no matching entry is found.
-        /// </returns>
-        public virtual IEnumerator<TValue> Get(string text)
-        {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
-
-            return Get(text.AsSpan());
         }
 
         /// <summary>
@@ -106,28 +75,12 @@ namespace ICU4N.Impl
 
         // ICU4N specific: Eliminatd Get(ICharSequence text, int start, int[] matchLen) because we can slice a ReadOnlySpan<char>
 
-        public virtual IEnumerator<TValue> Get(string text, out int matchLength)
-        {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
-
-            return Get(text.AsSpan(), out matchLength);
-        }
-
         public virtual IEnumerator<TValue> Get(ReadOnlySpan<char> text, out int matchLength)
         {
             LongestMatchHandler<TValue> handler = new LongestMatchHandler<TValue>();
             Find(text, handler);
             matchLength = handler.MatchLength;
             return handler.Matches;
-        }
-
-        public virtual void Find(string text, IResultHandler<TValue> handler)
-        {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
-
-            Find(text.AsSpan(), handler);
         }
 
         public virtual void Find(ReadOnlySpan<char> text, IResultHandler<TValue> handler)

--- a/src/ICU4N/Impl/Trie2.cs
+++ b/src/ICU4N/Impl/Trie2.cs
@@ -508,21 +508,6 @@ namespace ICU4N.Impl
         /// <param name="text">A text string to be iterated over.</param>
         /// <param name="index">The starting iteration position within the input text.</param>
         /// <returns>The <see cref="CharSequenceEnumerator"/>.</returns>
-        public virtual CharSequenceEnumerator GetCharSequenceEnumerator(string text, int index) // ICU4N specific
-        {
-            if (text is null)
-                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause
-
-            return new CharSequenceEnumerator(this, text.AsSpan(), index);
-        }
-
-        /// <summary>
-        /// Create an enumerator that will produce the values from the <see cref="Trie2"/> for
-        /// the sequence of code points in an input text.
-        /// </summary>
-        /// <param name="text">A text string to be iterated over.</param>
-        /// <param name="index">The starting iteration position within the input text.</param>
-        /// <returns>The <see cref="CharSequenceEnumerator"/>.</returns>
         public virtual CharSequenceEnumerator GetCharSequenceEnumerator(ReadOnlySpan<char> text, int index)
         {
             return new CharSequenceEnumerator(this, text, index);

--- a/src/ICU4N/Impl/UCharacterName.cs
+++ b/src/ICU4N/Impl/UCharacterName.cs
@@ -108,16 +108,6 @@ namespace ICU4N.Impl
         /// <param name="choice">Selector to indicate if argument name is a Unicode 1.0 or the most current version.</param>
         /// <param name="name">The name to search for.</param>
         /// <returns>Code point.</returns>
-        public int GetCharFromName(UCharacterNameChoice choice, string? name)
-            => GetCharFromName(choice, name.AsSpan());
-
-        /// <summary>
-        /// Find a character by its name and return its code point value
-        /// 
-        /// </summary>
-        /// <param name="choice">Selector to indicate if argument name is a Unicode 1.0 or the most current version.</param>
-        /// <param name="name">The name to search for.</param>
-        /// <returns>Code point.</returns>
         public int GetCharFromName(UCharacterNameChoice choice, ReadOnlySpan<char> name)
         {
             // checks for illegal arguments
@@ -850,7 +840,7 @@ namespace ICU4N.Impl
             {
                 int prefixlen = m_prefix_.Length;
                 if (name.Length < prefixlen ||
-                    !m_prefix_.AsSpan().Equals(name.Slice(0, prefixlen), StringComparison.Ordinal)) // ICU4N: Checked 2nd parameter
+                    !m_prefix_.Equals(name.Slice(0, prefixlen), StringComparison.Ordinal)) // ICU4N: Checked 2nd parameter
                 {
                     return -1;
                 }
@@ -925,7 +915,7 @@ namespace ICU4N.Impl
             internal int Add(int[] set, int maxlength)
             {
                 // prefix length
-                int length = UCharacterName.Add(set, m_prefix_.AsSpan());
+                int length = UCharacterName.Add(set, m_prefix_);
                 switch (m_type_)
                 {
                     case TYPE_0_:
@@ -1524,7 +1514,7 @@ namespace ICU4N.Impl
                             int length = TYPE_NAMES_.Length;
                             for (int i = 0; i < length; ++i)
                             {
-                                if (type.CompareTo(TYPE_NAMES_[i].AsSpan(), StringComparison.Ordinal) == 0)
+                                if (type.CompareTo(TYPE_NAMES_[i], StringComparison.Ordinal) == 0)
                                 {
                                     if (GetType(result) == i)
                                     {
@@ -1620,7 +1610,7 @@ namespace ICU4N.Impl
                 // 2 for <>
                 // 1 for -
                 // 6 for most hex digits per code point
-                int length = 9 + Add(m_nameSet_, TYPE_NAMES_[i].AsSpan());
+                int length = 9 + Add(m_nameSet_, TYPE_NAMES_[i]);
                 if (length > maxlength)
                 {
                     maxlength = length;

--- a/src/ICU4N/Impl/UPropertyAliases.cs
+++ b/src/ICU4N/Impl/UPropertyAliases.cs
@@ -263,14 +263,6 @@ namespace ICU4N.Impl
             return 'A' <= c && c <= 'Z' ? c + 0x20 : c;
         }
 
-        private bool ContainsName(BytesTrie trie, string name)
-        {
-            if (name is null)
-                throw new ArgumentNullException(nameof(name));
-
-            return ContainsName(trie, name.AsSpan());
-        }
-
         private bool ContainsName(BytesTrie trie, ReadOnlySpan<char> name)
         {
             Result result = Result.NoValue;
@@ -411,21 +403,6 @@ namespace ICU4N.Impl
             return TryGetName(nameGroupOffset, (int)nameChoice, out error, out result);
         }
 
-        private int GetPropertyOrValueEnum(int bytesTrieOffset, string alias)
-        {
-            BytesTrie trie = new BytesTrie(bytesTries, bytesTrieOffset);
-            if (ContainsName(trie, alias))
-            {
-                return trie.GetValue();
-            }
-            else
-            {
-#pragma warning disable 612, 618
-                return (int)UPropertyConstants.Undefined;
-#pragma warning restore 612, 618
-            }
-        }
-
         private int GetPropertyOrValueEnum(int bytesTrieOffset, ReadOnlySpan<char> alias)
         {
             BytesTrie trie = new BytesTrie(bytesTries, bytesTrieOffset);
@@ -449,46 +426,10 @@ namespace ICU4N.Impl
         /// If the property name is not known, this method returns
         /// <see cref="UPropertyConstants.Undefined"/>.
         /// </summary>
-        public int GetPropertyEnum(string alias)
-        {
-            return GetPropertyOrValueEnum(0, alias);
-        }
-
-
-        /// <summary>
-        /// Returns a property enum given one of its property names.
-        /// If the property name is not known, this method returns
-        /// <see cref="UPropertyConstants.Undefined"/>.
-        /// </summary>
         public int GetPropertyEnum(ReadOnlySpan<char> alias)
         {
             return GetPropertyOrValueEnum(0, alias);
         }
-
-        /// <summary>
-        /// Returns a value enum given a property enum and one of its value names.
-        /// </summary>
-        /// <seealso cref="TryGetPropertyValueEnum(UProperty, string, out int)"/>
-        public int GetPropertyValueEnum(UProperty property, string alias)
-        {
-            int valueMapIndex = FindProperty((int)property);
-            if (valueMapIndex == 0)
-            {
-                throw new ArgumentException(
-                        "Invalid property enum " + property + " (0x" + string.Format("{0:x2}", (int)property) + ")");
-            }
-            valueMapIndex = valueMaps[valueMapIndex + 1];
-            if (valueMapIndex == 0)
-            {
-                throw new ArgumentException(
-                        "Property " + property + " (0x" + string.Format("{0:x2}", (int)property) +
-                        ") does not have named values");
-            }
-            // valueMapIndex is the start of the property's valueMap,
-            // where the first word is the BytesTrie offset.
-            return GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
-        }
-
 
         /// <summary>
         /// Returns a value enum given a property enum and one of its value names.
@@ -513,34 +454,6 @@ namespace ICU4N.Impl
             // where the first word is the BytesTrie offset.
             return GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
         }
-
-        /// <summary>
-        /// Returns a value enum given a property enum and one of its value names.
-        /// </summary>
-        /// <seealso cref="GetPropertyValueEnum(UProperty, string)"/>
-        public bool TryGetPropertyValueEnum(UProperty property, string alias, out int result)
-        {
-#pragma warning disable 612, 618
-            result = (int)UPropertyConstants.Undefined;
-#pragma warning restore 612, 618
-            int valueMapIndex = FindProperty((int)property);
-            if (valueMapIndex == 0)
-            {
-                return false;
-            }
-            valueMapIndex = valueMaps[valueMapIndex + 1];
-            if (valueMapIndex == 0)
-            {
-                return false;
-            }
-            // valueMapIndex is the start of the property's valueMap,
-            // where the first word is the BytesTrie offset.
-            result = GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
-#pragma warning disable 612, 618
-            return result != (int)UPropertyConstants.Undefined;
-#pragma warning restore 612, 618
-        }
-
 
         /// <summary>
         /// Returns a value enum given a property enum and one of its value names.
@@ -590,25 +503,6 @@ namespace ICU4N.Impl
         //    // where the first word is the BytesTrie offset.
         //    return GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
         //}
-
-        /// <summary>
-        /// Compare two property names, returning &lt;0, 0, or >0.  The
-        /// comparison is that described as "loose" matching in the
-        /// Property*Aliases.txt files.
-        /// </summary>
-        public static int Compare(string stra, string strb)
-        {
-            // ICU4N: Added null logic so we don't throw
-            if (stra is null)
-            {
-                if (strb is null) return 0;
-                return 1;
-            }
-            else if (strb is null)
-                return -1;
-
-            return Compare(stra.AsSpan(), strb.AsSpan());
-        }
 
         /// <summary>
         /// Compare two property names, returning &lt;0, 0, or >0.  The

--- a/src/ICU4N/Impl/UPropertyAliases.cs
+++ b/src/ICU4N/Impl/UPropertyAliases.cs
@@ -509,6 +509,25 @@ namespace ICU4N.Impl
         /// comparison is that described as "loose" matching in the
         /// Property*Aliases.txt files.
         /// </summary>
+        public static int Compare(string stra, string strb)
+        {
+            // ICU4N: Added null logic so we don't throw
+            if (stra is null)
+            {
+                if (strb is null) return 0;
+                return 1;
+            }
+            else if (strb is null)
+                return -1;
+
+            return Compare(stra.AsSpan(), strb.AsSpan());
+        }
+
+        /// <summary>
+        /// Compare two property names, returning &lt;0, 0, or >0.  The
+        /// comparison is that described as "loose" matching in the
+        /// Property*Aliases.txt files.
+        /// </summary>
         public static int Compare(ReadOnlySpan<char> stra, ReadOnlySpan<char> strb)
         {
             // Note: This implementation is a literal copy of

--- a/src/ICU4N/Impl/UnicodeSetStringSpan.cs
+++ b/src/ICU4N/Impl/UnicodeSetStringSpan.cs
@@ -8,7 +8,7 @@ using System.Runtime.CompilerServices;
 namespace ICU4N.Impl
 {
     /// <summary>
-    /// Implement <see cref="Span(string, int, SpanCondition)"/> etc. for a set with strings.
+    /// Implement <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/> etc. for a set with strings.
     /// Avoid recursion because of its exponential complexity.
     /// Instead, try multiple paths at once and track them with an IndexList.
     /// </summary>
@@ -41,7 +41,7 @@ namespace ICU4N.Impl
         /// <summary>The spanLength is >=0xfe.</summary>
         internal const byte LONG_SPAN = (ALL_CP_CONTAINED - 1);
 
-        /// <summary>Set for <see cref="Span(string, int, SpanCondition)"/>. Same as parent but without strings.</summary>
+        /// <summary>Set for <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/>. Same as parent but without strings.</summary>
         private UnicodeSet spanSet;
 
         /// <summary>
@@ -53,8 +53,8 @@ namespace ICU4N.Impl
         /// <summary>The strings of the parent set.</summary>
         private IList<string> strings;
 
-        /// <summary>The lengths of <see cref="Span(string, int, SpanCondition)"/>, 
-        /// <see cref="SpanBack(string, int, SpanCondition)"/> etc. for each string.</summary>
+        /// <summary>The lengths of <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/>, 
+        /// <see cref="SpanBack(ReadOnlySpan{char}, int, SpanCondition)"/> etc. for each string.</summary>
         private short[] spanLengths;
 
         /// <summary>Maximum lengths of relevant strings.</summary>
@@ -63,7 +63,7 @@ namespace ICU4N.Impl
         /// <summary>Are there strings that are not fully contained in the code point set?</summary>
         private bool someRelevant;
 
-        /// <summary>Set up for all variants of <see cref="SpanBack(string, int, SpanCondition)"/>?</summary>
+        /// <summary>Set up for all variants of <see cref="SpanBack(ReadOnlySpan{char}, int, SpanCondition)"/>?</summary>
         private bool all;
 
         /// <summary>Span helper</summary>
@@ -72,7 +72,7 @@ namespace ICU4N.Impl
         private readonly object syncLock = new object();
 
         /// <summary>
-        /// Constructs for all variants of <see cref="Span(string, int, SpanCondition)"/>, or only for any one variant.
+        /// Constructs for all variants of <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/>, or only for any one variant.
         /// Initializes as little as possible, for single use.
         /// </summary>
         public UnicodeSetStringSpan(UnicodeSet set, IList<string> setStrings, int which)
@@ -253,8 +253,8 @@ namespace ICU4N.Impl
         }
 
         /// <summary>
-        /// Do the strings need to be checked in <see cref="Span(string, int, SpanCondition)"/> etc.?
-        /// Returns true if strings need to be checked (call <see cref="Span(string, int, SpanCondition)"/> here),
+        /// Do the strings need to be checked in <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/> etc.?
+        /// Returns true if strings need to be checked (call <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/> here),
         /// false if not (use a BMPSet for best performance).
         /// </summary>
         public bool NeedsStringSpanUTF16 => someRelevant;
@@ -385,21 +385,6 @@ namespace ICU4N.Impl
          *     then try another spanLength=spanSet.span(SpanCondition.CONTAINED).
          *     Stop if spanLength==0, otherwise continue the loop.
          */
-
-        /// <summary>
-        /// Spans a string.
-        /// </summary>
-        /// <param name="s">The string to be spanned.</param>
-        /// <param name="start">The start index that the span begins.</param>
-        /// <param name="spanCondition">The span condition.</param>
-        /// <returns>The limit (exclusive end) of the span.</returns>
-        public int Span(string s, int start, SpanCondition spanCondition)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return Span(s.AsSpan(), start, spanCondition);
-        }
 
         /// <summary>
         /// Spans a string.
@@ -639,29 +624,6 @@ namespace ICU4N.Impl
         /// <param name="spanCondition">The span condition.</param>
         /// <param name="outCount">The count.</param>
         /// <returns>The limit (exclusive end) of the span.</returns>
-        public int SpanAndCount(string s, int start, SpanCondition spanCondition,
-            out int outCount) // ICU4N TODO: API - Would this be more useful if we returned length instead of limit?
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return SpanAndCount(s.AsSpan(), start, spanCondition, out outCount);
-        }
-
-        /// <summary>
-        /// Spans a string and counts the smallest number of set elements on any path across the span.
-        /// </summary>
-        /// <remarks>
-        /// For proper counting, we cannot ignore strings that are fully contained in code point spans.
-        /// <para/>
-        /// If the set does not have any fully-contained strings, then we could optimize this
-        /// like Span(), but such sets are likely rare, and this is at least still linear.
-        /// </remarks>
-        /// <param name="s">The string to be spanned.</param>
-        /// <param name="start">The start index that the span begins.</param>
-        /// <param name="spanCondition">The span condition.</param>
-        /// <param name="outCount">The count.</param>
-        /// <returns>The limit (exclusive end) of the span.</returns>
         public int SpanAndCount(ReadOnlySpan<char> s, int start, SpanCondition spanCondition,
             out int outCount) // ICU4N TODO: API - Would this be more useful if we returned length instead of limit?
         {
@@ -759,21 +721,6 @@ namespace ICU4N.Impl
                 outCount = count;
                 return pos;
             }
-        }
-
-        /// <summary>
-        /// Span a string backwards.
-        /// </summary>
-        /// <param name="s">The string to be spanned.</param>
-        /// <param name="length"></param>
-        /// <param name="spanCondition">The span condition</param>
-        /// <returns>The string index which starts the span (i.e. inclusive).</returns>
-        public int SpanBack(string s, int length, SpanCondition spanCondition)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return SpanBack(s.AsSpan(), length, spanCondition);
         }
 
         /// <summary>
@@ -1235,7 +1182,8 @@ namespace ICU4N.Impl
         /// List of offsets from the current position from where to try matching
         /// a code point or a string.
         /// Stores offsets rather than indexes to simplify the code and use the same list
-        /// for both increments (in <see cref="Span(string, int, SpanCondition)"/>) and decrements (in <see cref="SpanBack(string, int, SpanCondition)"/>).
+        /// for both increments (in <see cref="Span(ReadOnlySpan{char}, int, SpanCondition)"/>) and decrements
+        /// (in <see cref="SpanBack(ReadOnlySpan{char}, int, SpanCondition)"/>).
         /// 
         /// <para/>Assumption: The maximum offset is limited, and the offsets that are stored at any one time
         /// are relatively dense, that is,

--- a/src/ICU4N/Impl/Utility.cs
+++ b/src/ICU4N/Impl/Utility.cs
@@ -278,16 +278,6 @@ namespace ICU4N.Impl
             return buffer.ToString();
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Convert characters outside the range U+0020 to U+007F to
-        /// Unicode escapes, and convert backslash to a double backslash.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string Escape(string s)
-            => Escape(s.AsSpan());
-#endif
-
         /// <summary>
         /// Convert characters outside the range U+0020 to U+007F to
         /// Unicode escapes, and convert backslash to a double backslash.
@@ -351,22 +341,6 @@ namespace ICU4N.Impl
             /*t*/ (char)0x74, (char)0x09,
             /*v*/ (char)0x76, (char)0x0b
         };
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Convert an escape to a 32-bit code point value.  We attempt
-        /// to parallel the icu4c unescapeAt() function.
-        /// </summary>
-        /// <param name="s">The character sequence to escape.</param>
-        /// <param name="offset16">An offset to the character
-        /// <em>after</em> the backslash.  Upon return offset16 will
-        /// be updated to point after the escape sequence.</param>
-        /// <returns>Character value from 0 to 10FFFF, or -1 on error.</returns>
-        // ICU4N: To fix lack of implicit conversion
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int UnescapeAt(string s, ref int offset16)
-            => UnescapeAt(s.AsSpan(), ref offset16);
-#endif
 
         /// <summary>
         /// Convert an escape to a 32-bit code point value.  We attempt
@@ -516,17 +490,6 @@ namespace ICU4N.Impl
             return c;
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
-        /// </summary>
-        /// <exception cref="ArgumentException">If an invalid escape is seen.</exception>
-        // ICU4N: To fix lack of implicit conversion
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string Unescape(string s)
-            => Unescape(s.AsSpan());
-#endif
-
         /// <summary>
         /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
         /// </summary>
@@ -573,15 +536,6 @@ namespace ICU4N.Impl
             }
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
-        /// Leave invalid escape sequences unchanged.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static string UnescapeLeniently(string s)
-            => UnescapeLeniently(s.AsSpan());
-#endif
         /// <summary>
         /// Convert all escapes in a given string using <see cref="UnescapeAt(ReadOnlySpan{char}, ref int)"/>.
         /// Leave invalid escape sequences unchanged.

--- a/src/ICU4N/Impl/Utility.cs
+++ b/src/ICU4N/Impl/Utility.cs
@@ -524,7 +524,7 @@ namespace ICU4N.Impl
                     int e = UnescapeAt(s, ref pos); // ICU4N: Changed array to ref parameter
                     if (e < 0)
                     {
-                        throw new ArgumentException(StringHelper.Concat("Invalid escape sequence ".AsSpan(), s.Slice(i - 1, Math.Min(i + 8, s.Length) - (i - 1)))); // ICU4N: Corrected 2nd parameter
+                        throw new ArgumentException(StringHelper.Concat("Invalid escape sequence ", s.Slice(i - 1, Math.Min(i + 8, s.Length) - (i - 1)))); // ICU4N: Corrected 2nd parameter
                     }
                     result.AppendCodePoint(e);
                     i = pos;
@@ -690,24 +690,12 @@ namespace ICU4N.Impl
         /// Convert a string to comma-separated groups of 4 hex uppercase
         /// digits.  E.g., hex('ab') => "0041,0042".
         /// </summary>
-        public static string Hex(string s)
-        {
-            if (s is null)
-                throw new ArgumentNullException(nameof(s));
-
-            return Hex(s.AsSpan());
-        }
-
-        /// <summary>
-        /// Convert a string to comma-separated groups of 4 hex uppercase
-        /// digits.  E.g., hex('ab') => "0041,0042".
-        /// </summary>
         public static string Hex(ReadOnlySpan<char> s)
         {
             ValueStringBuilder sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             try
             {
-                Hex(s, 4, ",".AsSpan(), true, ref sb);
+                Hex(s, 4, ",", true, ref sb);
                 return sb.ToString();
             }
             finally

--- a/src/ICU4N/Number/NumberPropertyMapper.cs
+++ b/src/ICU4N/Number/NumberPropertyMapper.cs
@@ -495,19 +495,19 @@ namespace ICU4N.Numerics
                 bool negative = (flags & AffixPatternProviderFlags.NegativeSubpattern) != 0;
                 if (prefix && negative)
                 {
-                    return negPrefixPattern.AsSpan();
+                    return negPrefixPattern;
                 }
                 else if (prefix)
                 {
-                    return posPrefixPattern.AsSpan();
+                    return posPrefixPattern;
                 }
                 else if (negative)
                 {
-                    return negSuffixPattern.AsSpan();
+                    return negSuffixPattern;
                 }
                 else
                 {
-                    return posSuffixPattern.AsSpan();
+                    return posSuffixPattern;
                 }
             }
         }

--- a/src/ICU4N/Support/Collections/DictionaryExtensions.Memory.cs
+++ b/src/ICU4N/Support/Collections/DictionaryExtensions.Memory.cs
@@ -21,7 +21,7 @@ namespace ICU4N.Support.Collections
             int hashCode = ascii.GetHashCode(key);
             foreach (string itemKey in dictionary.Keys)
             {
-                if (ascii.GetHashCode(itemKey) == hashCode && ascii.Equals(key, itemKey.AsSpan()))
+                if (ascii.GetHashCode(itemKey) == hashCode && ascii.Equals(key, itemKey))
                     return true;
             }
             return false;
@@ -41,7 +41,7 @@ namespace ICU4N.Support.Collections
             int hashCode = ascii.GetHashCode(key);
             foreach (var kvp in dictionary)
             {
-                if (ascii.GetHashCode(kvp.Key) == hashCode && ascii.Equals(key, kvp.Key.AsSpan()))
+                if (ascii.GetHashCode(kvp.Key) == hashCode && ascii.Equals(key, kvp.Key))
                 {
                     value = kvp.Value;
                     return true;

--- a/src/ICU4N/Support/Globalization/LocaleDisplayNames/DataTableCultureDisplayNames.cs
+++ b/src/ICU4N/Support/Globalization/LocaleDisplayNames/DataTableCultureDisplayNames.cs
@@ -167,7 +167,7 @@ namespace ICU4N.Globalization
             ValueStringBuilder sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);
             try
             {
-                SimpleFormatterImpl.CompileToStringMinMaxArguments(sep.AsSpan(), ref sb, 2, 2);
+                SimpleFormatterImpl.CompileToStringMinMaxArguments(sep, ref sb, 2, 2);
                 this.separatorFormat = sb.AsSpan().ToString();
 
                 string pattern = langData.Get("localeDisplayPattern", "pattern");
@@ -175,7 +175,7 @@ namespace ICU4N.Globalization
                 {
                     pattern = "{0} ({1})";
                 }
-                SimpleFormatterImpl.CompileToStringMinMaxArguments(pattern.AsSpan(), ref sb, 2, 2);
+                SimpleFormatterImpl.CompileToStringMinMaxArguments(pattern, ref sb, 2, 2);
                 this.format = sb.AsSpan().ToString();
                 if (pattern.Contains("（"))
                 {
@@ -197,7 +197,7 @@ namespace ICU4N.Globalization
                 {
                     keyTypePattern = "{0}={1}";
                 }
-                SimpleFormatterImpl.CompileToStringMinMaxArguments(keyTypePattern.AsSpan(), ref sb, 2, 2);
+                SimpleFormatterImpl.CompileToStringMinMaxArguments(keyTypePattern, ref sb, 2, 2);
                 this.keyTypeFormat = sb.AsSpan().ToString();
             }
             finally
@@ -395,7 +395,7 @@ namespace ICU4N.Globalization
                             else if (!key.Equals(keyDisplayName))
                             {
                                 string keyValue = SimpleFormatterImpl.FormatCompiledPattern(
-                                    keyTypeFormat.AsSpan(), keyDisplayName, valueDisplayName);
+                                    keyTypeFormat, keyDisplayName, valueDisplayName);
                                 AppendWithSep(keyValue, ref buf);
                             }
                             else
@@ -414,7 +414,7 @@ namespace ICU4N.Globalization
                 if (buf.Length > 0)
                 {
                     resultName = SimpleFormatterImpl.FormatCompiledPattern(
-                        format.AsSpan(), resultName.AsSpan(), buf.AsSpan());
+                        format, resultName, buf.AsSpan());
                 }
             }
             finally
@@ -683,7 +683,7 @@ namespace ICU4N.Globalization
             }
             else
             {
-                SimpleFormatterImpl.FormatAndReplace(separatorFormat.AsSpan(), ref b, null, b.AsSpan(), s.AsSpan());
+                SimpleFormatterImpl.FormatAndReplace(separatorFormat, ref b, null, b.AsSpan(), s);
             }
         }
 

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/ModulusSubstitution.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/ModulusSubstitution.cs
@@ -80,8 +80,8 @@ namespace ICU4N.Globalization
 
             if (divisor == 0)
             { // this will cause recursion
-                throw new InvalidOperationException(StringHelper.Concat(("Substitution with bad divisor (" + divisor.ToString(CultureInfo.InvariantCulture) + ") ").AsSpan(), description.Slice(0, pos), // ICU4N: Checked 2nd parameter
-                        " | ".AsSpan(), description.Slice(pos)));
+                throw new InvalidOperationException(StringHelper.Concat("Substitution with bad divisor (", divisor.ToString(CultureInfo.InvariantCulture), ") ", description.Slice(0, pos), // ICU4N: Checked 2nd parameter
+                        " | ", description.Slice(pos)));
             }
 
             // the >>> token doesn't alter how this substitution calculates the

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/MultiplierSubstitution.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/MultiplierSubstitution.cs
@@ -56,8 +56,8 @@ namespace ICU4N.Globalization
 
             if (divisor == 0)
             { // this will cause recursion
-                throw new InvalidOperationException(StringHelper.Concat("Substitution with divisor 0 ".AsSpan(), description.Slice(0, pos), // ICU4N: Checked 2nd parameter
-                             " | ".AsSpan(), description.Slice(pos)));
+                throw new InvalidOperationException(StringHelper.Concat("Substitution with divisor 0 ", description.Slice(0, pos), // ICU4N: Checked 2nd parameter
+                             " | ", description.Slice(pos)));
             }
         }
 

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRule.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRule.cs
@@ -353,19 +353,6 @@ namespace ICU4N.Globalization
             this.ruleText = ParseRuleDescriptor(descriptor, description).ToString();
         }
 
-        /// <summary>
-        /// Intializes a new instance of <see cref="NumberFormatRule"/> for simple cases where we don't have any substitutions,
-        /// such as <c>"Inf", decimalFormatSymbols.Infinity</c> or <c>"NaN", decimalFormatSymbols.NaN</c>.
-        /// </summary>
-        /// <param name="owner">The <see cref="RuleBasedNumberFormat"/> that owns this rule.</param>
-        /// <param name="descriptor">The rule's descriptor (such as "Inf" or "NaN").</param>
-        /// <param name="description">The rule's description, minus the descriptor.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="owner"/> is <c>null</c>.</exception>
-        public NumberFormatRule(INumberFormatRules owner, string descriptor, string description)
-            : this(owner, descriptor.AsSpan(), description.AsSpan())
-        {
-        }
-
         private static ReadOnlySpan<char> RemoveLeadingApostrophe(ReadOnlySpan<char> description)
             => description.Length > 0 && description[0] == '\'' ? description.Slice(1) : description;
 
@@ -632,7 +619,7 @@ namespace ICU4N.Globalization
                 // Use the string as is - there were no substitutions to remove
                 this.ruleText = ruleText.ToString();
             }
-            ExtractPluralRules(this.ruleText.AsSpan());
+            ExtractPluralRules(this.ruleText);
         }
 
         /// <summary>
@@ -994,7 +981,7 @@ namespace ICU4N.Globalization
                     ? new ValueStringBuilder(stackalloc char[newRuleTextLength])
                     : new ValueStringBuilder(newRuleTextLength);
 
-                ruleTextCopy.Append(ruleText.AsSpan());
+                ruleTextCopy.Append(ruleText);
                 if (sub2 != null)
                 {
                     ruleTextCopy.Insert(sub2.Pos, sub2String.AsSpan());

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRuleSet.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRuleSet.cs
@@ -163,11 +163,7 @@ namespace ICU4N.Globalization
             {
                 // if the description doesn't begin with a rule set name, its
                 // name is "%default"
-                name = "%default"
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                    .AsSpan()
-#endif
-                    ;
+                name = "%default";
                 isParseable = true;
                 return description;
             }

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
@@ -233,24 +233,10 @@ namespace ICU4N.Globalization
             => ruleText.Slice(ruleName.Length).TrimStart(PatternProps.WhiteSpace).TrimEnd(';');
 
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        internal NumberFormatRules(string description)
-            : this(description.AsSpan(), stripWhiteSpace: true)
-        {
-        }
-#endif
-
         internal NumberFormatRules(ReadOnlySpan<char> description)
             : this(description, stripWhiteSpace: true)
         {
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        private NumberFormatRules(string description, bool stripWhiteSpace)
-            : this(description.AsSpan(), stripWhiteSpace)
-        {
-        }
-#endif
 
         private NumberFormatRules(ReadOnlySpan<char> description, bool stripWhiteSpace) // ICU4N TODO: Add a localizations parameter? We need to work out a way to allow users to supply these, but they don't matter for built-in rules. The jagged array is really ugly, but we should probably include an overload for compatibility reasons.
         {
@@ -468,11 +454,7 @@ namespace ICU4N.Globalization
             }
             // ICU4N: We must heap allocate here because the ValueStringBuilder may return from the
             // stack, which is out of scope after this point.
-            return result.ToString()
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                .AsSpan()
-#endif
-                ;
+            return result.ToString();
         }
 
         //-----------------------------------------------------------------------

--- a/src/ICU4N/Support/Globalization/UCultureInfo.cs
+++ b/src/ICU4N/Support/Globalization/UCultureInfo.cs
@@ -985,8 +985,8 @@ namespace ICU4N.Globalization
             /* total mondo hack for Norwegian, fortunately the main NY case is handled earlier */
             if (!foundVariant)
             {
-                if (parser.TryGetLanguage(buffer, out int languageLength) && buffer.Slice(0, languageLength).SequenceEqual("nb".AsSpan())
-                    && parser.TryGetVariant(buffer, out int variantLength) && buffer.Slice(0, variantLength).SequenceEqual("NY".AsSpan()))
+                if (parser.TryGetLanguage(buffer, out int languageLength) && buffer.Slice(0, languageLength).SequenceEqual("nb")
+                    && parser.TryGetVariant(buffer, out int variantLength) && buffer.Slice(0, variantLength).SequenceEqual("NY"))
                 {
                     parser.SetBaseName(LscvToID("nn", parser.GetScript(), parser.GetCountry(), null));
                 }
@@ -3293,7 +3293,7 @@ namespace ICU4N.Globalization
             if (languageTag == null)
                 throw new ArgumentNullException(nameof(languageTag));
 
-            LanguageTag.TryParse(languageTag.AsSpan(), out LanguageTag tag, out _);
+            LanguageTag.TryParse(languageTag, out LanguageTag tag, out _);
             InternalLocaleBuilder bldr = new InternalLocaleBuilder();
             bldr.SetLanguageTag(tag);
             return GetInstance(bldr.GetBaseLocale(), bldr.GetLocaleExtensions());

--- a/src/ICU4N/Support/IcuNumber.Formatting.cs
+++ b/src/ICU4N/Support/IcuNumber.Formatting.cs
@@ -93,7 +93,7 @@ namespace ICU4N
 
                 // We didn't have enough buffer on the stack. Do it the slow way.
                 string temp = value.ToString(format.ToString(), nfi);
-                AppendConvertedDigits(ref sb, temp.AsSpan(), info!);
+                AppendConvertedDigits(ref sb, temp, info!);
             }
         }
 
@@ -187,7 +187,7 @@ namespace ICU4N
 
                 // We didn't have enough buffer on the stack. Do it the slow way.
                 string temp = value.ToString(format.ToString(), nfi);
-                AppendConvertedDigits(ref sb, temp.AsSpan(), info!);
+                AppendConvertedDigits(ref sb, temp, info!);
             }
             return null;
         }
@@ -215,7 +215,7 @@ namespace ICU4N
 
                 // We didn't have enough buffer on the stack. Do it the slow way.
                 string temp = value.ToString(format.ToString(), nfi);
-                AppendConvertedDigits(ref sb, temp.AsSpan(), info!);
+                AppendConvertedDigits(ref sb, temp, info!);
             }
             return null;
         }
@@ -394,7 +394,7 @@ namespace ICU4N
             // If no pattern was applied, return the formatted number.
             if (messagePattern is null || messagePattern.PartCount == 0)
             {
-                FormatDouble(ref sb, value, format.AsSpan(), info!, numberGroupSizesOverride);
+                FormatDouble(ref sb, value, format, info!, numberGroupSizesOverride);
                 return;
             }
 
@@ -409,11 +409,11 @@ namespace ICU4N
             {
                 if (offset == 0)
                 {
-                    FormatDouble(ref temp, value, format.AsSpan(), info!, numberGroupSizesOverride); // ICU4N NOTE: This is how we might format decimal/BigDecimal at some point (just like in ICU4J)
+                    FormatDouble(ref temp, value, format, info!, numberGroupSizesOverride); // ICU4N NOTE: This is how we might format decimal/BigDecimal at some point (just like in ICU4J)
                 }
                 else
                 {
-                    FormatDouble(ref temp, numberMinusOffset, format.AsSpan(), info!, numberGroupSizesOverride);
+                    FormatDouble(ref temp, numberMinusOffset, format, info!, numberGroupSizesOverride);
                 }
 #pragma warning disable 612, 618
                 // ICU4N NOTE: This is how we get the values for 'v' and 'f'
@@ -437,7 +437,7 @@ namespace ICU4N
                 // both for the length and the value to parse.
                 var asciiInfo = (UNumberFormatInfo)info.Clone();
                 asciiInfo.nativeDigits = AsciiDigits;
-                decimalString = FormatDouble(numberMinusOffset, format.AsSpan(), asciiInfo, numberGroupSizesOverride);
+                decimalString = FormatDouble(numberMinusOffset, format, asciiInfo, numberGroupSizesOverride);
             }
 
             int dotIndex = decimalString.IndexOf('.');
@@ -665,7 +665,7 @@ namespace ICU4N
             {
                 // We're outside of our normal range that this framework can handle.
                 // The DecimalFormat will provide more accurate results.
-                FormatBigInteger(ref sb, value, info!.NumberPattern.AsSpan(), info, info.decimalPatternProperties.GroupingSizes);
+                FormatBigInteger(ref sb, value, info!.NumberPattern, info, info.decimalPatternProperties.GroupingSizes);
             }
         }
 
@@ -734,7 +734,7 @@ namespace ICU4N
             {
                 // We're outside of our normal range that this framework can handle.
                 // The DecimalFormat will provide more accurate results.
-                FormatBigInteger(ref sb, value, info!.NumberPattern.AsSpan(), info, info.decimalPatternProperties.GroupingSizes);
+                FormatBigInteger(ref sb, value, info!.NumberPattern, info, info.decimalPatternProperties.GroupingSizes);
             }
         }
 
@@ -971,7 +971,7 @@ namespace ICU4N
         {
             Debug.Assert(source != null);
 
-            if (source.AsSpan().TryCopyTo(destination))
+            if (source!.TryCopyTo(destination))
             {
                 charsWritten = source!.Length;
                 return true;

--- a/src/ICU4N/Support/MemoryExtensions.cs
+++ b/src/ICU4N/Support/MemoryExtensions.cs
@@ -38,80 +38,12 @@ namespace ICU4N
         }
 #endif
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-
-        /// <summary>
-        /// Reports the zero-based index of the first occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<char> span, string value, StringComparison comparisonType)
-        {
-            return System.MemoryExtensions.IndexOf(span, value.AsSpan(), comparisonType);
-        }
-
-
-        /// <summary>
-        /// Determines whether this <paramref name="span"/> and the specified <paramref name="other"/> span have the same characters
-        /// when compared using the specified <paramref name="comparisonType"/> option.
-        /// <param name="span">The source span.</param>
-        /// <param name="other">The value to compare with the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="other"/> are compared.</param>
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool Equals(this ReadOnlySpan<char> span, string other, StringComparison comparisonType)
-        {
-            return System.MemoryExtensions.Equals(span, other.AsSpan(), comparisonType);
-        }
-
-        /// <summary>
-        /// Determines whether the beginning of the <paramref name="span"/> matches the specified <paramref name="value"/> when compared using the specified <paramref name="comparisonType"/> option.
-        /// </summary>
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The sequence to compare to the beginning of the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool StartsWith(this ReadOnlySpan<char> span, string value, StringComparison comparisonType)
-        {
-            return System.MemoryExtensions.StartsWith(span, value.AsSpan(), comparisonType);
-        }
-
-        /// <summary>
-        /// Determines whether the end of the <paramref name="span"/> matches the specified <paramref name="value"/> when compared using the specified <paramref name="comparisonType"/> option.
-        /// </summary>
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The sequence to compare to the end of the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool EndsWith(this ReadOnlySpan<char> span, string value, StringComparison comparisonType)
-        {
-            return System.MemoryExtensions.EndsWith(span, value.AsSpan(), comparisonType);
-        }
-#endif
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<char> span, string value, int startIndex, StringComparison comparisonType)
-        {
-            return IndexOf(span, value.AsSpan(), startIndex, comparisonType);
-        }
-#endif
         public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
         {
             ReadOnlySpan<char> slice = span.Slice(startIndex);
             int pos = System.MemoryExtensions.IndexOf(slice, value, comparisonType);
             return pos < 0 ? -1 : pos + startIndex;
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int IndexOf(this ReadOnlySpan<char> span, string value, int startIndex, int count, StringComparison comparisonType)
-        {
-            return IndexOf(span, value.AsSpan(), startIndex, count, comparisonType);
-        }
-#endif
 
         public static int IndexOf(this ReadOnlySpan<char> span, ReadOnlySpan<char> value, int startIndex, int count, StringComparison comparisonType)
         {
@@ -128,29 +60,6 @@ namespace ICU4N
         }
 
 #if !FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_COMPARISONTYPE
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.
-        /// <param name="span">The source span.</param>
-        /// <param name="value">The value to seek within the source span.</param>
-        /// <param name="comparisonType">One of the enumeration values that determines how the <paramref name="span"/> and <paramref name="value"/> are compared.</param>
-        /// </summary>
-        public static int LastIndexOf(this ReadOnlySpan<char> span, string value, StringComparison comparisonType)
-        {
-            CheckStringComparison(comparisonType);
-
-            if (comparisonType == StringComparison.Ordinal)
-            {
-                return span.LastIndexOf(value.AsSpan());
-            }
-
-            // Hack for platforms older than .NET Core, since this overload didn't exist.
-            // ICU4N TODO: Optimize (this is rarely used)
-            return span.ToString().LastIndexOf(value, comparisonType);
-        }
-
-#endif
 
         /// <summary>
         /// Reports the zero-based index of the last occurrence of the specified <paramref name="value"/> in the current <paramref name="span"/>.

--- a/src/ICU4N/Support/Numerics/BigMath/ParseNumbers.cs
+++ b/src/ICU4N/Support/Numerics/BigMath/ParseNumbers.cs
@@ -229,7 +229,7 @@ namespace ICU4N.Numerics.BigMath
             if (((flags & IsTight) == 0) && ((flags & NoSpace) == 0))
             {
                 int iBefore = i;
-                EatWhiteSpace(s.AsSpan(), ref i);
+                EatWhiteSpace(s, ref i);
                 if (i == end)
                     return ParsingStatus.Format_EmptyInputString;
                     //throw new FormatException(SR.Format_EmptyInputString);
@@ -301,7 +301,7 @@ namespace ICU4N.Numerics.BigMath
             {
                 //if (!Integer.TryParse(s, substrStart, substrEnd - substrStart, radix, out int bigRadixDigit)) // ICU4N TODO: When this is put into J2N - call the internal method
                 int grabNumbersStart = substrStart;
-                if (!TryGrabInts(radix, s.AsSpan(), ref grabNumbersStart, substrEnd, isUnsigned: true, out int bigRadixDigit))
+                if (!TryGrabInts(radix, s, ref grabNumbersStart, substrEnd, isUnsigned: true, out int bigRadixDigit))
                 {
                     //exception = null;
                     //result = null;

--- a/src/ICU4N/Support/Text/OpenStringBuilder.CharSequence.cs
+++ b/src/ICU4N/Support/Text/OpenStringBuilder.CharSequence.cs
@@ -116,14 +116,6 @@ namespace ICU4N.Text
         public int IndexOf(ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
             => AsSpan(startIndex).IndexOf(value, comparisonType) + startIndex;
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        public int IndexOf(string value, StringComparison comparisonType)
-            => AsSpan().IndexOf(value.AsSpan(), comparisonType);
-
-        public int IndexOf(string value, int startIndex, StringComparison comparisonType)
-            => AsSpan(startIndex).IndexOf(value.AsSpan(), comparisonType) + startIndex;
-#endif
-
         public int LastIndexOf(char value) => _chars.AsSpan(0, _pos).LastIndexOf(value);
 
         public int LastIndexOf(ReadOnlySpan<char> value, StringComparison comparisonType)
@@ -131,15 +123,6 @@ namespace ICU4N.Text
 
         public int LastIndexOf(ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
             => AsSpan(0, startIndex + 1).LastIndexOf(value, comparisonType);
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        public int LastIndexOf(string value, StringComparison comparisonType)
-            => AsSpan().LastIndexOf(value.AsSpan(), comparisonType);
-
-        public int LastIndexOf(string value, int startIndex, StringComparison comparisonType)
-            => AsSpan(0, startIndex + 1).LastIndexOf(value.AsSpan(), comparisonType);
-#endif
-
 
         #region ICharSequence
 

--- a/src/ICU4N/Support/Text/OpenStringBuilder.cs
+++ b/src/ICU4N/Support/Text/OpenStringBuilder.cs
@@ -1,4 +1,5 @@
-﻿using J2N.Text;
+﻿using ICU4N.Support.Text;
+using J2N.Text;
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -175,11 +176,7 @@ namespace ICU4N.Text
 
             int remaining = _pos - index;
             _chars.AsSpan(index, remaining).CopyTo(_chars.AsSpan(index + count));
-            s
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                .AsSpan()
-#endif
-                .CopyTo(_chars.AsSpan(index));
+            s.CopyTo(_chars.AsSpan(index));
             _pos += count;
             return this;
         }
@@ -270,11 +267,7 @@ namespace ICU4N.Text
                 Grow(s.Length);
             }
 
-            s
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                .AsSpan()
-#endif
-                .CopyTo(_chars.AsSpan(pos));
+            s.CopyTo(_chars.AsSpan(pos));
             _pos += s.Length;
         }
 

--- a/src/ICU4N/Support/Text/SplitTokenizerEnumerator.cs
+++ b/src/ICU4N/Support/Text/SplitTokenizerEnumerator.cs
@@ -7,163 +7,6 @@ namespace ICU4N.Text
     /// </summary>
     internal static class SplitTokenizerExtensions
     {
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>. This is
-        /// intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiter.Length, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>. This is
-        /// intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="delimiterLength">The actual length of the delimiter. This is the value used when determining the strings to return.
-        /// This can be used to adjust the beginning of the text in the output, for example, matching on the string ';%' the actual length is 2,
-        /// but including the '%' character as part of the (next) output string, this can be specified as 1 here.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, int delimiterLength)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiterLength, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, string trimChars)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiter.Length, trimChars.AsSpan(), TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <param name="trimBehavior">Bitwise flags to determine whether to trim the beginning of the string, the end of the string, or both.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, string trimChars, TrimBehavior trimBehavior)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiter.Length, trimChars.AsSpan(), trimBehavior);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="delimiterLength">The actual length of the delimiter. This is the value used when determining the strings to return.
-        /// This can be used to adjust the beginning of the text in the output, for example, matching on the string ';%' the actual length is 2,
-        /// but including the '%' character as part of the (next) output string, this can be specified as 1 here.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, int delimiterLength, string trimChars)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiterLength, trimChars.AsSpan(), TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="delimiterLength">The actual length of the delimiter. This is the value used when determining the strings to return.
-        /// This can be used to adjust the beginning of the text in the output, for example, matching on the string ';%' the actual length is 2,
-        /// but including the '%' character as part of the (next) output string, this can be specified as 1 here.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <param name="trimBehavior">Bitwise flags to determine whether to trim the beginning of the string, the end of the string, or both.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, int delimiterLength, string trimChars, TrimBehavior trimBehavior)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiterLength, trimChars.AsSpan(), trimBehavior);
-        }
-
-        // string, ReadOnlySpan<char>
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, ReadOnlySpan<char> trimChars)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiter.Length, trimChars, TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <param name="trimBehavior">Bitwise flags to determine whether to trim the beginning of the string, the end of the string, or both.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiter.Length, trimChars, trimBehavior);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="delimiterLength">The actual length of the delimiter. This is the value used when determining the strings to return.
-        /// This can be used to adjust the beginning of the text in the output, for example, matching on the string ';%' the actual length is 2,
-        /// but including the '%' character as part of the (next) output string, this can be specified as 1 here.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, int delimiterLength, ReadOnlySpan<char> trimChars)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiterLength, trimChars, TrimBehavior.StartAndEnd);
-        }
-
-        /// <summary>
-        /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>.
-        /// Trims the <paramref name="trimChars"/> from each token. This is intended for use within a foreach loop.
-        /// </summary>
-        /// <param name="text">This <see cref="ReadOnlySpan{T}"/>.</param>
-        /// <param name="delimiter">The sequence to consider delimiters between tokens.</param>
-        /// <param name="delimiterLength">The actual length of the delimiter. This is the value used when determining the strings to return.
-        /// This can be used to adjust the beginning of the text in the output, for example, matching on the string ';%' the actual length is 2,
-        /// but including the '%' character as part of the (next) output string, this can be specified as 1 here.</param>
-        /// <param name="trimChars">The span which contains the set of characters to remove.</param>
-        /// <param name="trimBehavior">Bitwise flags to determine whether to trim the beginning of the string, the end of the string, or both.</param>
-        /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
-        /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
-        public static SplitTokenizerEnumerator AsTokens(this ReadOnlySpan<char> text, string delimiter, int delimiterLength, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
-        {
-            return new SplitTokenizerEnumerator(text, delimiter.AsSpan(), delimiterLength, trimChars, trimBehavior);
-        }
-#endif
-
-
         /// <summary>
         /// Creates an enumerator that splits this <see cref="ReadOnlySpan{T}"/> based on the <paramref name="delimiter"/>. This is
         /// intended for use within a foreach loop.
@@ -304,11 +147,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiter.Length, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiter.Length, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -324,11 +163,7 @@ namespace ICU4N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter, int delimiterLength)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiterLength, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiterLength, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -341,11 +176,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter, ReadOnlySpan<char> trimChars)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiter.Length, trimChars, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiter.Length, trimChars, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -359,11 +190,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiter.Length, trimChars, trimBehavior);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiter.Length, trimChars, trimBehavior);
-#endif
         }
 
         /// <summary>
@@ -380,11 +207,7 @@ namespace ICU4N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter, int delimiterLength, ReadOnlySpan<char> trimChars)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiterLength, trimChars, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiterLength, trimChars, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -402,11 +225,7 @@ namespace ICU4N.Text
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="delimiterLength"/> is less than zero.</exception>
         public static SplitTokenizerEnumerator AsTokens(this string text, ReadOnlySpan<char> delimiter, int delimiterLength, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, delimiterLength, trimChars, trimBehavior);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, delimiterLength, trimChars, trimBehavior);
-#endif
         }
 
         /// <summary>
@@ -418,11 +237,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, char delimiter)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -435,11 +250,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, char delimiter, ReadOnlySpan<char> trimChars)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, trimChars, TrimBehavior.StartAndEnd);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, trimChars, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -453,11 +264,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="SplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static SplitTokenizerEnumerator AsTokens(this string text, char delimiter, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new SplitTokenizerEnumerator(text, delimiter, trimChars, trimBehavior);
-#else
-            return new SplitTokenizerEnumerator(text.AsSpan(), delimiter, trimChars, trimBehavior);
-#endif
         }
 
         /// <summary>
@@ -658,11 +465,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="MultiDelimiterSplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static MultiDelimiterSplitTokenizerEnumerator AsTokens(this string text, char[] delimiters)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new MultiDelimiterSplitTokenizerEnumerator(text, delimiters, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#else
-            return new MultiDelimiterSplitTokenizerEnumerator(text.AsSpan(), delimiters, ReadOnlySpan<char>.Empty, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -675,11 +478,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="MultiDelimiterSplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static MultiDelimiterSplitTokenizerEnumerator AsTokens(this string text, char[] delimiters, ReadOnlySpan<char> trimChars)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new MultiDelimiterSplitTokenizerEnumerator(text, delimiters, trimChars, TrimBehavior.StartAndEnd);
-#else
-            return new MultiDelimiterSplitTokenizerEnumerator(text.AsSpan(), delimiters, trimChars, TrimBehavior.StartAndEnd);
-#endif
         }
 
         /// <summary>
@@ -693,11 +492,7 @@ namespace ICU4N.Text
         /// <returns>A <see cref="MultiDelimiterSplitTokenizerEnumerator"/> that can be used to enumerate the tokens.</returns>
         public static MultiDelimiterSplitTokenizerEnumerator AsTokens(this string text, char[] delimiters, ReadOnlySpan<char> trimChars, TrimBehavior trimBehavior)
         {
-#if FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
             return new MultiDelimiterSplitTokenizerEnumerator(text, delimiters, trimChars, trimBehavior);
-#else
-            return new MultiDelimiterSplitTokenizerEnumerator(text.AsSpan(), delimiters, trimChars, trimBehavior);
-#endif
         }
 
         /// <summary>

--- a/src/ICU4N/Support/Text/StringExtensions.cs
+++ b/src/ICU4N/Support/Text/StringExtensions.cs
@@ -17,7 +17,7 @@ namespace ICU4N.Support.Text
         /// <param name="destination">The span into which to copy this string's contents.</param>
         /// <exception cref="ArgumentException">If <paramref name="destination"/> is too short.</exception>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static void CopyTo(this string s, Span<char> destination) // ICU4N TODO: Move to J2N?
+        public static void CopyTo(this string s, Span<char> destination)
         {
             if (s is null)
                 throw new ArgumentNullException(nameof(s));
@@ -37,7 +37,7 @@ namespace ICU4N.Support.Text
         /// <param name="destination">The span into which to copy this string's contents.</param>
         /// <returns>true if the data was copied; false if the destination was too short to fit the contents of the string.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static bool TryCopyTo(this string s, Span<char> destination) // ICU4N TODO: Move to J2N?
+        public static bool TryCopyTo(this string s, Span<char> destination)
         {
             if (s is null)
                 throw new ArgumentNullException(nameof(s));

--- a/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.CharSequence.cs
@@ -319,14 +319,6 @@ namespace ICU4N.Text
         public int IndexOf(ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
             => AsSpan(startIndex).IndexOf(value, comparisonType) + startIndex;
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        public int IndexOf(string value, StringComparison comparisonType)
-            => AsSpan().IndexOf(value.AsSpan(), comparisonType);
-
-        public int IndexOf(string value, int startIndex, StringComparison comparisonType)
-            => AsSpan(startIndex).IndexOf(value.AsSpan(), comparisonType) + startIndex;
-#endif
-
         public int LastIndexOf(char value) => _chars.Slice(0, _pos).LastIndexOf(value);
 
         public int LastIndexOf(ReadOnlySpan<char> value, StringComparison comparisonType)
@@ -334,13 +326,5 @@ namespace ICU4N.Text
 
         public int LastIndexOf(ReadOnlySpan<char> value, int startIndex, StringComparison comparisonType)
             => AsSpan(0, startIndex + 1).LastIndexOf(value, comparisonType);
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        public int LastIndexOf(string value, StringComparison comparisonType)
-            => AsSpan().LastIndexOf(value.AsSpan(), comparisonType);
-
-        public int LastIndexOf(string value, int startIndex, StringComparison comparisonType)
-            => AsSpan(0, startIndex + 1).LastIndexOf(value.AsSpan(), comparisonType);
-#endif
     }
 }

--- a/src/ICU4N/Support/Text/ValueStringBuilder.IcuNumber.Formatting.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.IcuNumber.Formatting.cs
@@ -13,12 +13,6 @@ namespace ICU4N.Text
     {
         private const int CharStackBufferSize = 32;
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AppendFormat(long value, string? format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
-            => AppendFormat(value, format.AsSpan(), info, numberGroupSizesOverride);
-#endif
-
         internal void AppendFormat(long value, ReadOnlySpan<char> format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
         {
             if (IcuNumber.TryFormatInt64(value, format, info, _chars.Slice(_pos), out int charsWritten, numberGroupSizesOverride))
@@ -47,13 +41,6 @@ namespace ICU4N.Text
                 }
             }
         }
-
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void AppendFormat(double value, string? format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
-            => AppendFormat(value, format.AsSpan(), info, numberGroupSizesOverride);
-#endif
 
         internal void AppendFormat(double value, ReadOnlySpan<char> format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
         {
@@ -84,12 +71,6 @@ namespace ICU4N.Text
             }
         }
 
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void InsertFormat(int index, long value, string? format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
-            => InsertFormat(index, value, format.AsSpan(), info, numberGroupSizesOverride);
-#endif
-
         internal void InsertFormat(int index, long value, ReadOnlySpan<char> format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
         {
             Span<char> buffer = stackalloc char[CharStackBufferSize];
@@ -112,12 +93,6 @@ namespace ICU4N.Text
                 Insert(index, IcuNumber.FormatInt64(value, format, info, numberGroupSizesOverride));
             }
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal void InsertFormat(int index, double value, string? format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
-            => InsertFormat(index, value, format.AsSpan(), info, numberGroupSizesOverride);
-#endif
 
         internal void InsertFormat(int index, double value, ReadOnlySpan<char> format, UNumberFormatInfo info, int[]? numberGroupSizesOverride = null)
         {

--- a/src/ICU4N/Support/Text/ValueStringBuilder.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using ICU4N.Support.Text;
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -273,11 +274,7 @@ namespace ICU4N.Text
 
             int remaining = _pos - index;
             _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
-            s
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                .AsSpan()
-#endif
-                .CopyTo(_chars.Slice(index));
+            s.CopyTo(_chars.Slice(index));
             _pos += count;
             UpdateMaxLength();
         }
@@ -369,11 +366,7 @@ namespace ICU4N.Text
                 Grow(s.Length);
             }
 
-            s
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                .AsSpan()
-#endif
-                .CopyTo(_chars.Slice(pos));
+            s.CopyTo(_chars.Slice(pos));
             _pos += s.Length;
             UpdateMaxLength();
         }

--- a/src/ICU4N/Text/CanonicalIterator.cs
+++ b/src/ICU4N/Text/CanonicalIterator.cs
@@ -268,7 +268,7 @@ namespace ICU4N.Text
                     ReadOnlySpan<char> chStr = UTF16.ValueOf(source, i);
                     foreach (string s in subpermute)
                     {
-                        string piece = StringHelper.Concat(chStr, s.AsSpan());
+                        string piece = StringHelper.Concat(chStr, s);
                         //if (PROGRESS) System.out.println("  Piece: " + piece);
                         output.Add(piece);
                     }
@@ -414,7 +414,7 @@ namespace ICU4N.Text
                         segmentBuffer.AppendCodePoint(cp2);
                         foreach (string item in remainder)
                         {
-                            result.Add(StringHelper.Concat(segmentBuffer.AsSpan(), item.AsSpan()));
+                            result.Add(StringHelper.Concat(segmentBuffer.AsSpan(), item));
                         }
                     }
                 }

--- a/src/ICU4N/Text/Normalizer.cs
+++ b/src/ICU4N/Text/Normalizer.cs
@@ -947,7 +947,7 @@ namespace ICU4N.Text
         [Obsolete("ICU 56 Use Normalizer2 instead.")]
         public static string Compose(string str, bool compat, NormalizerUnicodeVersion unicodeVersion)
         {
-            return GetComposeNormalizer2(compat, (int)unicodeVersion).Normalize(str.AsSpan());
+            return GetComposeNormalizer2(compat, (int)unicodeVersion).Normalize(str);
         }
 
         /// <summary>
@@ -1061,7 +1061,7 @@ namespace ICU4N.Text
         [Obsolete("ICU 56 Use Normalizer2 instead.")]
         public static string Decompose(string str, bool compat, NormalizerUnicodeVersion unicodeVersion)
         {
-            return GetDecomposeNormalizer2(compat, (int)unicodeVersion).Normalize(str.AsSpan());
+            return GetDecomposeNormalizer2(compat, (int)unicodeVersion).Normalize(str);
         }
 
         /// <summary>
@@ -1324,7 +1324,7 @@ namespace ICU4N.Text
         [Obsolete("ICU 56 Use Normalizer2 instead.")]
         public static QuickCheckResult QuickCheck(string source, NormalizerMode mode, NormalizerUnicodeVersion unicodeVersion)
         {
-            return GetModeInstance(mode).GetNormalizer2((int)unicodeVersion).QuickCheck(source.AsSpan());
+            return GetModeInstance(mode).GetNormalizer2((int)unicodeVersion).QuickCheck(source);
         }
 
         /// <summary>
@@ -1376,7 +1376,7 @@ namespace ICU4N.Text
         [Obsolete("ICU 56 Use Normalizer2 instead.")]
         public static bool IsNormalized(string str, NormalizerMode mode, NormalizerUnicodeVersion unicodeVersion)
         {
-            return GetModeInstance(mode).GetNormalizer2((int)unicodeVersion).IsNormalized(str.AsSpan());
+            return GetModeInstance(mode).GetNormalizer2((int)unicodeVersion).IsNormalized(str);
         }
 
         /// <summary>
@@ -1610,7 +1610,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.8</stable>
         public static int Compare(string s1, string s2, NormalizerComparison comparison, FoldCase foldCase, NormalizerUnicodeVersion unicodeVersion)
         {
-            return InternalCompare(s1.AsSpan(), s2.AsSpan(), (int)comparison | (int)foldCase, (int)unicodeVersion);
+            return InternalCompare(s1, s2, (int)comparison | (int)foldCase, (int)unicodeVersion);
         }
 
         // ---------------------------------
@@ -1870,7 +1870,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.8</stable>
         public static int Compare(int char32a, string str2, NormalizerComparison comparison, FoldCase foldCase, NormalizerUnicodeVersion unicodeVersion)
         {
-            return InternalCompare(UTF16.ValueOf(char32a, stackalloc char[2]), str2.AsSpan(), (int)comparison | (int)foldCase, (int)unicodeVersion);
+            return InternalCompare(UTF16.ValueOf(char32a, stackalloc char[2]), str2, (int)comparison | (int)foldCase, (int)unicodeVersion);
         }
 
         // ---------------------------------

--- a/src/ICU4N/Text/Normalizer2.cs
+++ b/src/ICU4N/Text/Normalizer2.cs
@@ -240,7 +240,7 @@ namespace ICU4N.Text
                     NormalizeSecondAndAppend(ref sb, src.AsSpan(spanLength, src.Length - spanLength)); // ICU4N: Corrected 2nd substring parameter
                     return sb.ToString();
                 }
-                Normalize(src.AsSpan(), ref sb);
+                Normalize(src, ref sb);
                 return sb.ToString();
             }
             finally

--- a/src/ICU4N/Text/PluralRules.cs
+++ b/src/ICU4N/Text/PluralRules.cs
@@ -424,7 +424,7 @@ namespace ICU4N.Text
             if (description is null)
                 throw new ArgumentNullException(nameof(description));
 
-            ParseRuleStatus status = TryParseDescription(description.AsSpan(), out PluralRules result, out ReadOnlySpan<char> source, out ReadOnlySpan<char> context);
+            ParseRuleStatus status = TryParseDescription(description, out PluralRules result, out ReadOnlySpan<char> source, out ReadOnlySpan<char> context);
             if (status != ParseRuleStatus.OK)
                 ThrowParseException(status, source.ToString(), context.ToString());
             return result;
@@ -473,7 +473,7 @@ namespace ICU4N.Text
             if (description is null)
                 throw new ArgumentNullException(nameof(description));
 
-            ParseRuleStatus status = TryParseDescription(description.AsSpan(), out result, out ReadOnlySpan<char> _, out ReadOnlySpan<char> _);
+            ParseRuleStatus status = TryParseDescription(description, out result, out ReadOnlySpan<char> _, out ReadOnlySpan<char> _);
             return status == ParseRuleStatus.OK;
         }
 
@@ -1407,7 +1407,7 @@ namespace ICU4N.Text
 #pragma warning restore 612, 618
         }
 
-        internal class SimpleTokenizer
+        internal class SimpleTokenizer // ICU4N TODO: API - Move this to the test that calls it. The only purpose of keeping it is to verify the port.
         {
             private static readonly UnicodeSet BREAK_AND_IGNORE = new UnicodeSet(0x09, 0x0a, 0x0c, 0x0d, 0x20, 0x20).Freeze();
             private static readonly UnicodeSet BREAK_AND_KEEP = new UnicodeSet('!', '!', '%', '%', ',', ',', '.', '.', '=', '=').Freeze();
@@ -1459,11 +1459,6 @@ namespace ICU4N.Text
             {
                 this.source = source;
                 Current = default;
-            }
-
-            public SimpleTokenizerEnumerator(string source)
-                : this(source.AsSpan())
-            {
             }
 
             // Needed to be compatible with the foreach operator
@@ -1724,12 +1719,14 @@ namespace ICU4N.Text
                             // at this point, either we are out of tokens, or t is ','
                             if (low > high)
                             {
-                                token = string.Concat(low.ToString(CultureInfo.InvariantCulture), "~", high.ToString(CultureInfo.InvariantCulture)).AsSpan();
+                                // ICU4N TODO: This may be a bug. Need to check whether this string goes out of scope.
+                                token = string.Concat(low.ToString(CultureInfo.InvariantCulture), "~", high.ToString(CultureInfo.InvariantCulture));
                                 return ParseRuleStatus.ConstraintUnexpectedToken;
                             }
                             else if (mod != 0 && high >= mod)
                             {
-                                token = string.Concat(low.ToString(CultureInfo.InvariantCulture), ">mod=", mod.ToString(CultureInfo.InvariantCulture)).AsSpan();
+                                // ICU4N TODO: This may be a bug. Need to check whether this string goes out of scope.
+                                token = string.Concat(low.ToString(CultureInfo.InvariantCulture), ">mod=", mod.ToString(CultureInfo.InvariantCulture));
                                 return ParseRuleStatus.ConstraintUnexpectedToken;
                             }
                             valueList.Add(low);
@@ -2454,7 +2451,7 @@ namespace ICU4N.Text
                     // ICU4N: Hard-coded rule will always succeed unless TryParseRule has a bug. So, we don't need a try version of this method.
 
                     // make sure we have always have an 'other' a rule
-                    ParseRuleStatus status = TryParseRule("other:".AsSpan(), out otherRule, out ReadOnlySpan<char> source, out ReadOnlySpan<char> context);
+                    ParseRuleStatus status = TryParseRule("other:", out otherRule, out ReadOnlySpan<char> source, out ReadOnlySpan<char> context);
                     if (status != ParseRuleStatus.OK)
                         ThrowParseException(status, source.ToString(), context.ToString());
                 }

--- a/src/ICU4N/Text/PluralRules.cs
+++ b/src/ICU4N/Text/PluralRules.cs
@@ -1076,17 +1076,6 @@ namespace ICU4N.Text
 
             /// <internal/>
             [Obsolete("This API is ICU internal only.")]
-            public virtual ReadOnlySpan<char> AsSpan() // ICU4N: Added to patch platforms that don't implicitly convert string to ReadOnlySpan<char>
-            {
-                return ToString()
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                    .AsSpan()
-#endif
-                    ;
-            }
-
-            /// <internal/>
-            [Obsolete("This API is ICU internal only.")]
 #pragma warning disable 809
             public override string ToString()
 #pragma warning restore 809
@@ -1293,7 +1282,7 @@ namespace ICU4N.Text
                         }
                         if (!TryCheckDecimal(sampleType2, sample)) // ICU4N TODO: This can never fail - it should be an assert rather than an error.
                         {
-                            source = sample.AsSpan();
+                            source = sample.ToString(); // ICU4N TODO: API - ideally, there would be a TryGetChars() method that writes to Span<char> to avoid this unnecessary allocation.
                             return ParseRuleStatus.IllformedNumberRange;
                         }
                         samples2.Add(new FixedDecimalRange(sample, sample));
@@ -1312,12 +1301,12 @@ namespace ICU4N.Text
                         }
                         if (!TryCheckDecimal(sampleType2, start)) // ICU4N TODO: This can never fail - it should be an assert rather than an error.
                         {
-                            source = start.AsSpan();
+                            source = start.ToString(); // ICU4N TODO: API - ideally, there would be a TryGetChars() method that writes to Span<char> to avoid this unnecessary allocation.
                             return ParseRuleStatus.IllformedNumberRange;
                         }
                         if (!TryCheckDecimal(sampleType2, end)) // ICU4N TODO: This can never fail - it should be an assert rather than an error.
                         {
-                            source = end.AsSpan();
+                            source = end.ToString(); // ICU4N TODO: API - ideally, there would be a TryGetChars() method that writes to Span<char> to avoid this unnecessary allocation.
                             return ParseRuleStatus.IllformedNumberRange;
                         }
                         samples2.Add(new FixedDecimalRange(start, end));
@@ -1771,11 +1760,7 @@ namespace ICU4N.Text
                         // Hack to exclude "is not 1,2"
                         if (lowBound != highBound && hackForCompatibility && !inRange)
                         {
-                            token = "is not <range>"
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-                                .AsSpan()
-#endif
-                                ;
+                            token = "is not <range>";
                             return ParseRuleStatus.ConstraintUnexpectedToken;
                         }
 
@@ -1849,12 +1834,6 @@ namespace ICU4N.Text
             // ICU4N: Checked 2nd arg
             return TryParseRule(description.Slice(0, x).Trim(), description.Slice(x + 1).Trim(), out result, out source, out context);
         }
-
-#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static bool TryParseRule(string keyword, string description, out Rule result)
-            => TryParseRule(keyword.AsSpan(), description.AsSpan(), out result);
-#endif
 
         // ICU4N: Added overload for use by PluralRulesLoader so it doesn't have to use StringBuilder
         internal static bool TryParseRule(ReadOnlySpan<char> keyword, ReadOnlySpan<char> description, out Rule result)

--- a/src/ICU4N/Text/SimpleFormatter.cs
+++ b/src/ICU4N/Text/SimpleFormatter.cs
@@ -122,7 +122,7 @@ namespace ICU4N.Text
         /// The max argument number + 1.
         /// </summary>
         /// <stable>ICU 57</stable>
-        public int ArgumentLimit => argumentLimit.HasValue ? argumentLimit.Value : (argumentLimit = SimpleFormatterImpl.GetArgumentLimit(compiledPattern.AsSpan())).Value;
+        public int ArgumentLimit => argumentLimit.HasValue ? argumentLimit.Value : (argumentLimit = SimpleFormatterImpl.GetArgumentLimit(compiledPattern)).Value;
 
         /// <summary>
         /// Formats the given values.
@@ -131,7 +131,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(params string[] values)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), values);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, values);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, params string[] values)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, values);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, values);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace ICU4N.Text
         internal StringBuilder FormatAndAppend(
             StringBuilder appendTo, Span<int> offsets, params string[] values) // ICU4N TODO: API - If we do this, we should probably make this IAppendable instead of StringBuilder
         {
-            return SimpleFormatterImpl.FormatAndAppend(compiledPattern.AsSpan(), appendTo, offsets, values);
+            return SimpleFormatterImpl.FormatAndAppend(compiledPattern, appendTo, offsets, values);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace ICU4N.Text
         internal StringBuilder FormatAndReplace(
             StringBuilder result, Span<int> offsets, params string[] values) // ICU4N TODO: API - If we do this, we should probably make this IAppendable instead of StringBuilder
         {
-            return SimpleFormatterImpl.FormatAndReplace(compiledPattern.AsSpan(), result, offsets, values);
+            return SimpleFormatterImpl.FormatAndReplace(compiledPattern, result, offsets, values);
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string GetTextWithNoArguments()
         {
-            return SimpleFormatterImpl.GetTextWithNoArguments(compiledPattern.AsSpan());
+            return SimpleFormatterImpl.GetTextWithNoArguments(compiledPattern);
         }
 
         /// <summary>
@@ -235,7 +235,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryGetTextWithNoArguments(Span<char> destination, out int charsLength)
         {
-            return SimpleFormatterImpl.TryGetTextWithNoArguments(compiledPattern.AsSpan(), destination, out charsLength);
+            return SimpleFormatterImpl.TryGetTextWithNoArguments(compiledPattern, destination, out charsLength);
         }
     }
 }

--- a/src/ICU4N/Text/SimpleFormatter.generated.cs
+++ b/src/ICU4N/Text/SimpleFormatter.generated.cs
@@ -24,7 +24,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0);
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4);
         }
 
         /// <summary>
@@ -89,7 +89,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6);
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8);
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
         }
 
         /// <summary>
@@ -179,7 +179,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10);
         }
 
         /// <summary>
@@ -200,7 +200,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11);
         }
 
         /// <summary>
@@ -222,7 +222,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12);
         }
 
         /// <summary>
@@ -245,7 +245,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13);
         }
 
         /// <summary>
@@ -269,7 +269,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13, ReadOnlySpan<char> value14)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14);
         }
 
         /// <summary>
@@ -294,7 +294,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13, ReadOnlySpan<char> value14, ReadOnlySpan<char> value15)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15);
         }
 
         #endregion Format
@@ -316,7 +316,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0);
         }
 
         /// <summary>
@@ -338,7 +338,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1);
         }
 
         /// <summary>
@@ -364,7 +364,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2);
         }
 
         /// <summary>
@@ -394,7 +394,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3);
         }
 
         /// <summary>
@@ -428,7 +428,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4);
         }
 
         /// <summary>
@@ -466,7 +466,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5);
         }
 
         /// <summary>
@@ -508,7 +508,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6);
         }
 
         /// <summary>
@@ -554,7 +554,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7);
         }
 
         /// <summary>
@@ -604,7 +604,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8);
         }
 
         /// <summary>
@@ -658,7 +658,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9);
         }
 
         /// <summary>
@@ -716,7 +716,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10);
         }
 
         /// <summary>
@@ -778,7 +778,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11);
         }
 
         /// <summary>
@@ -844,7 +844,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12);
         }
 
         /// <summary>
@@ -914,7 +914,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13);
         }
 
         /// <summary>
@@ -988,7 +988,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13, ReadOnlySpan<char> value14)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14);
         }
 
         /// <summary>
@@ -1066,7 +1066,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, ReadOnlySpan<char> value0, ReadOnlySpan<char> value1, ReadOnlySpan<char> value2, ReadOnlySpan<char> value3, ReadOnlySpan<char> value4, ReadOnlySpan<char> value5, ReadOnlySpan<char> value6, ReadOnlySpan<char> value7, ReadOnlySpan<char> value8, ReadOnlySpan<char> value9, ReadOnlySpan<char> value10, ReadOnlySpan<char> value11, ReadOnlySpan<char> value12, ReadOnlySpan<char> value13, ReadOnlySpan<char> value14, ReadOnlySpan<char> value15)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, value0, value1, value2, value3, value4, value5, value6, value7, value8, value9, value10, value11, value12, value13, value14, value15);
         }
 
 

--- a/src/ICU4N/Text/SimpleFormatter.generated.tt
+++ b/src/ICU4N/Text/SimpleFormatter.generated.tt
@@ -47,7 +47,7 @@ namespace ICU4N.Text
         /// <stable>ICU 57</stable>
         public string Format(<#=GenerateValuesParams(i + 1, "ReadOnlySpan<char>")#>)
         {
-            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern.AsSpan(), <#=GenerateValuesParams(i + 1)#>);
+            return SimpleFormatterImpl.FormatCompiledPattern(compiledPattern, <#=GenerateValuesParams(i + 1)#>);
         }
 
 <# } #>
@@ -73,7 +73,7 @@ namespace ICU4N.Text
         /// <draft>ICU 60.1</draft>
         public bool TryFormat(Span<char> destination, out int charsLength, <#=GenerateValuesParams(i + 1, "ReadOnlySpan<char>")#>)
         {
-            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern.AsSpan(), destination, out charsLength, <#=GenerateValuesParams(i + 1)#>);
+            return SimpleFormatterImpl.TryFormatCompiledPattern(compiledPattern, destination, out charsLength, <#=GenerateValuesParams(i + 1)#>);
         }
 
 <# } #>

--- a/src/ICU4N/Text/UTF16.cs
+++ b/src/ICU4N/Text/UTF16.cs
@@ -1510,7 +1510,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.6</stable>
         public static int IndexOf(string source, string str, int startIndex)
         {
-            return IndexOf(source, str, startIndex, StringComparison.CurrentCulture);
+            return IndexOf(source, str, startIndex, StringComparison.CurrentCulture); // ICU4N TODO: Culture sensitivy on IndexOf() is not particularly useful.
         }
 
         /// <summary>
@@ -1653,7 +1653,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.6</stable>
         public static int LastIndexOf(string source, string str)
         {
-            return LastIndexOf(source, str, StringComparison.CurrentCulture);
+            return LastIndexOf(source, str, StringComparison.CurrentCulture); // ICU4N TODO: Culture sensitivy on IndexOf() is not particularly useful.
         }
 
         /// <summary>

--- a/src/ICU4N/Text/UnicodeSet.cs
+++ b/src/ICU4N/Text/UnicodeSet.cs
@@ -1,5 +1,6 @@
 ﻿using ICU4N.Globalization;
 using ICU4N.Impl;
+using ICU4N.Support.Text;
 using ICU4N.Util;
 using J2N;
 using J2N.Collections.Generic.Extensions;
@@ -955,7 +956,7 @@ namespace ICU4N.Text
             if (pat != null && !escapeUnprintable)
             {
                 charsLength = pat.Length;
-                return pat.AsSpan().TryCopyTo(destination);
+                return pat.TryCopyTo(destination);
             }
             ValueStringBuilder result = new ValueStringBuilder(destination);
             try
@@ -1383,7 +1384,7 @@ namespace ICU4N.Text
                     // now keep checking string until we get the longest one
                     for (; ; )
                     {
-                        int tempLen = MatchesAt(text, offset, trial.AsSpan());
+                        int tempLen = MatchesAt(text, offset, trial);
                         if (lastLen > tempLen) goto strings_break;
                         lastLen = tempLen;
                         if (!it.MoveNext()) break;
@@ -1710,7 +1711,7 @@ namespace ICU4N.Text
                 throw new ArgumentNullException(nameof(s));
 
             CheckFrozen();
-            int cp = GetSingleCP(s.AsSpan());
+            int cp = GetSingleCP(s);
             if (cp < 0)
             {
                 strings.Add(s);
@@ -1783,7 +1784,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.0</stable>
         internal UnicodeSet AddAll(string s) // ICU4N specific - changed from public to internal (we are using UnionWithChars in .NET)
         {
-            return AddAll(s.AsSpan());
+            return AddAll(s.AsSpan()); // J2N: This overload is required because this wants to call the params string[] overload without the impl
         }
 
         /// <summary>
@@ -1927,7 +1928,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.0</stable>
         public static UnicodeSet FromAll(string s) // ICU4N TODO: API - rename FromChars() to match other APIs
         {
-            return new UnicodeSet().AddAll(s);
+            return new UnicodeSet().AddAll(s.AsSpan()); // J2N: AsSpan() is required because this wants to call the params string[] overload.
         }
 
         /// <summary>
@@ -1996,7 +1997,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.0</stable>
         internal UnicodeSet Retain(string cs) // ICU4N specific - changed from public to internal (we are using IntersectWith in .NET)
         {
-            int cp = GetSingleCP(cs.AsSpan());
+            int cp = GetSingleCP(cs);
             if (cp < 0)
             {
                 string s = cs;
@@ -2098,7 +2099,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.0</stable>
         public UnicodeSet Remove(string s)
         {
-            int cp = GetSingleCP(s.AsSpan());
+            int cp = GetSingleCP(s);
             if (cp < 0)
             {
                 strings.Remove(s);
@@ -2210,7 +2211,7 @@ namespace ICU4N.Text
         internal UnicodeSet Complement(string s) // ICU4N specific - changed from public to internal (we are using SymmetricExceptWith in .NET)
         {
             CheckFrozen();
-            int cp = GetSingleCP(s.AsSpan());
+            int cp = GetSingleCP(s);
             if (cp < 0)
             {
                 if (strings.Contains(s))
@@ -2494,7 +2495,7 @@ namespace ICU4N.Text
         /// <stable>ICU 2.0</stable>
         public bool Contains(string s)
         {
-            int cp = GetSingleCP(s.AsSpan());
+            int cp = GetSingleCP(s);
             if (cp < 0)
             {
                 return strings.Contains(s);
@@ -3772,9 +3773,9 @@ namespace ICU4N.Text
         internal virtual UnicodeSet AddAll(IEnumerable<char[]> source) // ICU4N specific - changed from public to internal (we are using UnionWith in .NET)
         {
             CheckFrozen();
-            foreach (var o in source)
+            foreach (char[] o in source)
             {
-                Add(o.AsSpan());
+                Add(o);
             }
             return this;
         }
@@ -4519,7 +4520,7 @@ namespace ICU4N.Text
                                     : new ValueStringBuilder(bufferLength);
                                 try
                                 {
-                                    MungeCharName(valueAlias.AsSpan(), ref buf);
+                                    MungeCharName(valueAlias, ref buf);
                                     int ch = UChar.GetCharFromExtendedName(buf.AsSpan());
                                     if (ch == -1)
                                     {
@@ -4550,7 +4551,7 @@ namespace ICU4N.Text
                                     : new ValueStringBuilder(bufferLength);
                                 try
                                 {
-                                    MungeCharName(valueAlias.AsSpan(), ref buf);
+                                    MungeCharName(valueAlias, ref buf);
                                     VersionInfo version = VersionInfo.GetInstance(buf.AsSpan());
                                     ApplyFilter(new VersionFilter(version), UPropertySource.PropertiesVectorsTrie);
                                     return this;

--- a/src/ICU4N/Text/UnicodeSetSpanner.cs
+++ b/src/ICU4N/Text/UnicodeSetSpanner.cs
@@ -228,7 +228,7 @@ namespace ICU4N.Text
             if (sequence is null)
                 throw new ArgumentNullException(nameof(sequence));
 
-            return ReplaceFrom(sequence.AsSpan(), ReadOnlySpan<char>.Empty, CountMethod.WholeSpan, SpanCondition.Simple);
+            return ReplaceFrom(sequence, ReadOnlySpan<char>.Empty, CountMethod.WholeSpan, SpanCondition.Simple);
         }
 
         /// <summary>
@@ -259,7 +259,7 @@ namespace ICU4N.Text
             if (sequence is null)
                 throw new ArgumentNullException(nameof(sequence));
 
-            return ReplaceFrom(sequence.AsSpan(), ReadOnlySpan<char>.Empty, CountMethod.WholeSpan, spanCondition);
+            return ReplaceFrom(sequence, ReadOnlySpan<char>.Empty, CountMethod.WholeSpan, spanCondition);
         }
 
         /// <summary>

--- a/src/ICU4N/Util/CharsTrieBuilder.cs
+++ b/src/ICU4N/Util/CharsTrieBuilder.cs
@@ -37,7 +37,7 @@ namespace ICU4N.Util
         public CharsTrieBuilder Add(string s, int value)
         {
 #pragma warning disable 612, 618
-            AddImpl(s.AsSpan(), value);
+            AddImpl(s, value);
 #pragma warning restore 612, 618
             return this;
         }

--- a/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
+++ b/src/tools/ICU4JResourceConverter/ICU4JResourceConverter.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
-    <TargetFramework Condition="'$(VisualStudioVersion)' &gt;= '16.10'">net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 


### PR DESCRIPTION
Fixes #120.

The project and CI updates are largely a copy of the approach taken in https://github.com/NightOwl888/J2N/pull/173.

This PR removes unnecessary calls to `AsSpan()` which were only done to make cross-TFM builds possible. C# 14.0 allows us to compile without this, meaning that .NET Core will use intrinsic conversions rather than method calls.

When scrubbing the APIs to eliminate (now) unnecessary calls to `System.String.AsSpan()`, several string overloads have been eliminated, particularly from the `ICU4N.Impl` namespace. This is a binary API breaking change, but at the build level there are no breaks for consumers that have already upgraded to C# 14.0 or are targeting only .NET Core 8.0+. For those who have not upgraded to C# 14.0 that are using .NET Framework/.NET Standard, you will need to explicitly call `System.String.AsSpan()` to reach these APIs.

> NOTE: The corresponding package to the ICU4N.Impl namespace in ICU4J is undocumented and is only meant for advanced users.

This has implications for Visual Studio 2022 build support. The LSP language parser is not available in VS 2022, so its Intellisense would show invalid compile errors on .NET Standard 2.0 and .NET Framework. Although this didn't affect the build in any way, those errors were a bit distracting, so support for VS 2022 was cut down to .NET Standard 2.0 and .NET Core only. This allows contributions to happen on VS 2022, but it means that using APIs that have TFM-specific behavior on those platforms won't be caught unless doing a command-line or CI build. Still, this is preferable over having dozens of false errors.

This PR officially drops build support for VS 2019, which only affects builds of ICU4N, not consumers of the packages.