### PR TITLE
Pin UI culture to fix failing tests on Linux

### DIFF
--- a/tests/ICU4N.Tests.Collation/Dev/Test/Collate/CollationServiceTest.cs
+++ b/tests/ICU4N.Tests.Collation/Dev/Test/Collate/CollationServiceTest.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Resources;
-using System.Runtime.InteropServices;
 
 namespace ICU4N.Dev.Test.Collate
 {
@@ -237,14 +236,12 @@ namespace ICU4N.Dev.Test.Collate
         }
 
         [Test]
+        // Pin UI culture: the factory's display-name table is keyed on en_US, and the
+        // single-arg Collator.GetDisplayName resolves the display locale from CurrentUICulture.
+        // Without this, the test fails on hosts whose default locale isn't en_US (e.g., Linux containers with POSIX/C). See #37.
+        [SetUICulture("en-US")]
         public void TestRegisterFactory()
         {
-
-#if NET5_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                Assert.Ignore("ICU4N TODO: Fails on Ubuntu 18.04 and Ubuntu 20.04 on .NET 5 and higher. See: https://github.com/NightOwl888/ICU4N/issues/37");
-#endif
-
             UCultureInfo fu_FU = new UCultureInfo("fu_FU");
             UCultureInfo fu_FU_FOO = new UCultureInfo("fu_FU_FOO");
 

--- a/tests/ICU4N.Tests/Dev/Test/Format/RbnfTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Format/RbnfTest.cs
@@ -1001,10 +1001,13 @@ namespace ICU4N.Dev.Test.Format
         }
 
         [Test]
+        // Pin UI culture: GetRuleSetDisplayName(name) (single-arg) resolves the display
+        // locale from CurrentUICulture, and only the en_US localization (e.g. "Simplified")
+        // matches the assertion — on hosts with a non-en_US default the rule set's raw
+        // lowercase name (e.g. "simplified") is returned. See #37.
+        [SetUICulture("en-US")]
         public void TestRuleSetDisplayName()
         {
-            Assume.That(!PlatformDetection.IsLinux, "LUCENENET TODO: On Linux, this test is failing for some unkown reason. Most likely, it is because the localizations array is not being processed correctly.");
-
             /*
              * Spellout rules for U.K. English.
              * This was borrowed from the rule sets for TestRuleSetDisplayName()

--- a/tests/ICU4N.Tests/Dev/Test/Util/CurrencyTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Util/CurrencyTest.cs
@@ -223,10 +223,12 @@ namespace ICU4N.Dev.Test.Util
         }
 
         [Test]
+        // Pin UI culture: Currency.GetSymbol() (no args) uses CurrentUICulture, and the
+        // USD symbol is "$" only under en_US — under the root locale it's "US$", which
+        // is what hosts with a non-en_US default (e.g., Linux containers with POSIX/C) see. See #37.
+        [SetUICulture("en-US")]
         public void TestCoverage()
         {
-            Assume.That(!PlatformDetection.IsLinux, "LUCENENET TODO: On Linux, this test is failing for some unkown reason.");
-
             Currency usd = Currency.GetInstance("USD");
             assertEquals($"USD.GetSymbol() in {UCultureInfo.CurrentUICulture.FullName}",
                     "$",


### PR DESCRIPTION
Fixes #37 

.NET on Linux by default uses an invariant culture as the UI culture. This PR uses the SetUICulture attribute to fix issues related to this, including #37.