### PR TITLE
Fixed `NumberFormatRules` to correctly strip whitespace without the value going out of scope (fixes #129)

### DIFF
--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRuleSet.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRuleSet.cs
@@ -235,6 +235,12 @@ namespace ICU4N.Globalization
             var ruleTokens = description.AsTokens(';', PatternProps.WhiteSpace, TrimBehavior.Start);
             while (ruleTokens.MoveNext())
             {
+                ReadOnlySpan<char> ruleToken = ruleTokens.Current.Text;
+                // ICU4N: Since we are not actually stripping whitespace at the top level, we need to
+                // ignore any empty cases here. This was handled by stripWhiteSpace() upstream.
+                if (ruleToken.IsEmpty)
+                    continue;
+
                 // makeRules (a factory method on NumberFormatRule) will return either
                 // a single rule or an array of rules.  Either way, add them
                 // to our rule vector

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
@@ -1,5 +1,4 @@
 ﻿using ICU4N.Impl;
-using ICU4N.Support.Text;
 using ICU4N.Text;
 using ICU4N.Util;
 using System;
@@ -7,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Resources;
-using System.Text;
 #nullable enable
 
 namespace ICU4N.Globalization
@@ -199,7 +197,7 @@ namespace ICU4N.Globalization
             return rulesCache.GetOrCreate(cacheKey, (key) =>
             {
                 string rules = GetRulesForCulture(bundle, key.Name, format, out string[][]? localizations);
-                return new NumberFormatRules(rules, stripWhiteSpace: false); // ICU4N TODO: localizations
+                return new NumberFormatRules(rules); // ICU4N TODO: localizations
             });
         }
 
@@ -232,38 +230,28 @@ namespace ICU4N.Globalization
         private static ReadOnlySpan<char> ExtractSpecialRule(ReadOnlySpan<char> ruleText, string ruleName)
             => ruleText.Slice(ruleName.Length).TrimStart(PatternProps.WhiteSpace).TrimEnd(';');
 
-
-        internal NumberFormatRules(ReadOnlySpan<char> description)
-            : this(description, stripWhiteSpace: true)
-        {
-        }
-
-        private NumberFormatRules(ReadOnlySpan<char> description, bool stripWhiteSpace) // ICU4N TODO: Add a localizations parameter? We need to work out a way to allow users to supply these, but they don't matter for built-in rules. The jagged array is really ugly, but we should probably include an overload for compatibility reasons.
+        internal NumberFormatRules(ReadOnlySpan<char> description) // ICU4N TODO: Add a localizations parameter? We need to work out a way to allow users to supply these, but they don't matter for built-in rules. The jagged array is really ugly, but we should probably include an overload for compatibility reasons.
         {
             if (description.Length == 0)
                 throw new ArgumentException("Empty rules description");
-
-            if (stripWhiteSpace)
-            {
-                description = StripWhiteSpace(description);
-            }
 
             // 1st pass: pre-flight parsing the description and count the number of
             // rule sets (";%" marks the end of one rule set and the beginning
             // of the next)
             int numRuleSets = 0; // ICU4N: Since we are counting the rule segments instead of the delimiters, we start at 0 instead of 1.
-            SplitTokenizerEnumerator ruleTokens = description.AsTokens(";%", delimiterLength: 1, PatternProps.WhiteSpace, TrimBehavior.Start);
-            while (ruleTokens.MoveNext())
+            var ruleSetTokens = new WhiteSpaceStrippingRuleSetTokenEnumerator(description);
+            while (ruleSetTokens.MoveNext())
             {
-                ReadOnlySpan<char> ruleToken = ruleTokens.Current.Text;
-                if (IsSpecialRule(ruleToken, LenientParseRuleName))
+                ReadOnlySpan<char> ruleSetToken = ruleSetTokens.Current;
+
+                if (IsSpecialRule(ruleSetToken, LenientParseRuleName))
                 {
-                    lenientParseRules = ExtractSpecialRule(ruleToken, LenientParseRuleName).ToString();
+                    lenientParseRules = ExtractSpecialRule(ruleSetToken, LenientParseRuleName).ToString();
                     continue; // Don't count this rule
                 }
-                if (IsSpecialRule(ruleToken, PostProcessRuleName))
+                if (IsSpecialRule(ruleSetToken, PostProcessRuleName))
                 {
-                    postProcessRules = ExtractSpecialRule(ruleToken, PostProcessRuleName).ToString();
+                    postProcessRules = ExtractSpecialRule(ruleSetToken, PostProcessRuleName).ToString();
                     continue; // Don't count this rule
                 }
 
@@ -286,15 +274,15 @@ namespace ICU4N.Globalization
             // sets before we can actually set everything up
             int curRuleSet = 0;
 
-            ruleTokens = description.AsTokens(";%", delimiterLength: 1, PatternProps.WhiteSpace, TrimBehavior.Start);
-            while (ruleTokens.MoveNext())
+            ruleSetTokens = new WhiteSpaceStrippingRuleSetTokenEnumerator(description);
+            while (ruleSetTokens.MoveNext())
             {
                 // Skip special rules
-                ReadOnlySpan<char> ruleToken = ruleTokens.Current.Text;
-                if (IsSpecialRule(ruleToken))
+                ReadOnlySpan<char> ruleSetToken = ruleSetTokens.Current;
+                if (IsSpecialRule(ruleSetToken))
                     continue;
 
-                var ruleSet = new NumberFormatRuleSet(this, ruleToken);
+                var ruleSet = new NumberFormatRuleSet(this, ruleSetToken);
                 ruleSets[curRuleSet] = ruleSet;
                 string currentName = ruleSet.Name;
                 ruleSetsMap[currentName] = ruleSet;
@@ -340,15 +328,15 @@ namespace ICU4N.Globalization
 
             // 3rd pass: finally, we can go back through the descriptions
             // and finish setting up the substructure
-            ruleTokens = description.AsTokens(";%", delimiterLength: 1, PatternProps.WhiteSpace, TrimBehavior.Start);
-            for (int i = 0; i < ruleSets.Length && ruleTokens.MoveNext(); )
+            ruleSetTokens = new WhiteSpaceStrippingRuleSetTokenEnumerator(description);
+            for (int i = 0; i < ruleSets.Length && ruleSetTokens.MoveNext(); )
             {
                 // Skip special rules
-                ReadOnlySpan<char> ruleToken = ruleTokens.Current.Text;
-                if (IsSpecialRule(ruleToken))
+                ReadOnlySpan<char> ruleSetToken = ruleSetTokens.Current;
+                if (IsSpecialRule(ruleSetToken))
                     continue;
 
-                ruleSets[i].ParseRules(ruleToken);
+                ruleSets[i].ParseRules(ruleSetToken);
                 i++;
             }
 
@@ -394,67 +382,169 @@ namespace ICU4N.Globalization
         }
 
         /// <summary>
-        /// This method is used by the constructor to strip whitespace between rules (i.e.,
-        /// after semicolons).
+        /// This enumerator is used by the constructor to strip whitespace between rules (i.e.,
+        /// after semicolons) while tokenizing the description into rule sets tokens. It emulates
+        /// the upstream behavior of <c>stripWhiteSpace()</c> while tokenizing so that we don't
+        /// have to allocate a new string with all the whitespace removed before parsing.
+        /// The main difference between this and a normal tokenizer is that it treats
+        /// runs of semicolons as a single delimiter and skips whitespace so that we don't
+        /// have to worry about extra semicolons or whitespace in the description.
+        /// It also ensures that the tokens it returns are stripped of any leading
+        /// or trailing whitespace so that we don't have to worry about that in the
+        /// the local parsing code. However, unlike <c>stripWhiteSpace()</c> we don't actually
+        /// modify the string, so the tokens returned may contain whitespace or duplicate semicolons
+        /// that were present in the original description that downstream tokenizers must account for.
         /// </summary>
-        /// <param name="description">The formatter description.</param>
-        /// <returns>The description with all the whitespace that follows semicolons
-        /// taken out.</returns>
-        private ReadOnlySpan<char> StripWhiteSpace(ReadOnlySpan<char> description) // ICU4N TODO: There is a bug here. We need to return a string to ensure this stays on the stack while we parse the rest. This could go out of scope before we are done. Ideally, we could "strip" the whitespace by ignoring it while parsing rather than calling a method like this.
+        /// <remarks>
+        /// The effective result is the tokenized description with all whitespace that
+        /// follows semicolons taken out, but only for the rule set rule delimiters.
+        /// </remarks>
+        private ref struct WhiteSpaceStrippingRuleSetTokenEnumerator
         {
-            int descriptionLength = description.Length;
+#pragma warning disable IDE0044 // Add readonly modifier
+            private /*readonly*/ ReadOnlySpan<char> description;
+#pragma warning restore IDE0044 // Add readonly modifier
+            private int position;
 
-            // since we don't have a method that deletes characters
-            // create a new StringBuffer to copy the text into
-            using ValueStringBuilder result = descriptionLength <= RuleStringStackBufferSize
-                ? new ValueStringBuilder(stackalloc char[RuleStringStackBufferSize])
-                : new ValueStringBuilder(descriptionLength);
-
-            // iterate through the characters...
-            int start = 0;
-            while (start < descriptionLength)
+            public WhiteSpaceStrippingRuleSetTokenEnumerator(ReadOnlySpan<char> description)
             {
-                // seek to the first non-whitespace character...
-                while (start < descriptionLength
-                       && PatternProps.IsWhiteSpace(description[start]))
-                {
-                    ++start;
-                }
-
-                //if the first non-whitespace character is semicolon, skip it and continue
-                if (start < descriptionLength && description[start] == ';')
-                {
-                    start += 1;
-                    continue;
-                }
-
-                // locate the next semicolon in the text and copy the text from
-                // our current position up to that semicolon into the result
-                int p = description.Slice(start).IndexOf(';') + start;
-                if (p == -1)
-                {
-                    // or if we don't find a semicolon, just copy the rest of
-                    // the string into the result
-                    result.Append(description.Slice(start));
-                    break;
-                }
-                else if (p < descriptionLength)
-                {
-                    result.Append(description.Slice(start, (p + 1) - start)); // ICU4N: Corrected 2nd parameter
-                    start = p + 1;
-                }
-                else
-                {
-                    // when we get here, we've seeked off the end of the string, and
-                    // we terminate the loop (we continue until *start* is -1 rather
-                    // than until *p* is -1, because otherwise we'd miss the last
-                    // rule in the description)
-                    break;
-                }
+                this.description = description;
+                position = 0;
+                Current = default;
             }
-            // ICU4N: We must heap allocate here because the ValueStringBuilder may return from the
-            // stack, which is out of scope after this point.
-            return result.ToString();
+
+            public ReadOnlySpan<char> Current { get; private set; }
+
+            public bool MoveNext()
+            {
+                int descriptionLength = description.Length;
+
+                //
+                // Emulate StripWhiteSpace() startup logic.
+                //
+                while (true)
+                {
+                    while (position < descriptionLength &&
+                        PatternProps.IsWhiteSpace(description[position]))
+                    {
+                        position++;
+                    }
+
+                    if (position < descriptionLength && description[position] == ';')
+                    {
+                        position++;
+                        continue;
+                    }
+
+                    break;
+                }
+
+                if (position >= descriptionLength)
+                    return false;
+
+                int start = position;
+
+                //
+                // Search for semicolons using the vectorized IndexOf()
+                // implementation rather than examining every character.
+                //
+                while (position < descriptionLength)
+                {
+#pragma warning disable IDE0057 // Use range operator
+                    int relativeIndex = description.Slice(position).IndexOf(';');
+#pragma warning restore IDE0057 // Use range operator
+
+                    if (relativeIndex < 0)
+                        break;
+
+                    position += relativeIndex;
+
+                    int p = position + 1;
+
+                    //
+                    // StripWhiteSpace() removes whitespace after ';'
+                    //
+                    while (p < descriptionLength &&
+                        PatternProps.IsWhiteSpace(description[p]))
+                    {
+                        p++;
+                    }
+
+                    //
+                    // StripWhiteSpace() then discards any semicolons
+                    // that appear before real content.
+                    //
+                    while (p < descriptionLength && description[p] == ';')
+                    {
+                        p++;
+
+                        while (p < descriptionLength &&
+                            PatternProps.IsWhiteSpace(description[p]))
+                        {
+                            p++;
+                        }
+                    }
+
+                    //
+                    // Equivalent to finding ";%" in the stripped stream.
+                    //
+                    if (p < descriptionLength && description[p] == '%')
+                    {
+                        Current = description.Slice(start, position - start + 1);
+
+                        position = p;
+                        return true;
+                    }
+
+                    //
+                    // Continue searching after the semicolon we just examined.
+                    //
+                    position++;
+                }
+
+                //
+                // Final token.
+                //
+                int end = descriptionLength;
+
+                //
+                // Strip trailing whitespace.
+                //
+                while (end > start &&
+                    PatternProps.IsWhiteSpace(description[end - 1]))
+                {
+                    end--;
+                }
+
+                //
+                // Strip trailing semicolon-only garbage.
+                //
+                while (end > start)
+                {
+                    int p = end;
+
+                    while (p > start &&
+                        PatternProps.IsWhiteSpace(description[p - 1]))
+                    {
+                        p--;
+                    }
+
+                    if (p > start && description[p - 1] == ';')
+                    {
+                        end = p - 1;
+                        continue;
+                    }
+
+                    break;
+                }
+
+#pragma warning disable IDE0057 // Use range operator
+                Current = description.Slice(start, end - start);
+#pragma warning restore IDE0057 // Use range operator
+                position = descriptionLength;
+
+                return Current.Length > 0;
+            }
         }
 
         //-----------------------------------------------------------------------

--- a/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
+++ b/src/ICU4N/Support/Globalization/RuleBasedNumberFormat/NumberFormatRules.cs
@@ -430,6 +430,7 @@ namespace ICU4N.Globalization
                         position++;
                     }
 
+                    // if the first non-whitespace character is semicolon, skip it and continue
                     if (position < descriptionLength && description[position] == ';')
                     {
                         position++;

--- a/tests/ICU4N.Tests/Dev/Test/Format/RbnfTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Format/RbnfTest.cs
@@ -2135,6 +2135,357 @@ namespace ICU4N.Dev.Test.Format
             assertEquals("infinity", rbnf.Format(double.PositiveInfinity));
             assertEquals("not a number", rbnf.Format(double.NaN));
         }
+
+
+        public class ICU4NSpecificTests
+        {
+            // ICU4N specific - extra parsing rules to compare against the original implementation
+
+            [Test]
+            public void TestDoubleSemicolonInsideRuleSet()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;;\n" +
+                    "1: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestWhitespaceAfterRuleSetName()
+            {
+                string rules =
+                    "%default:\n\n\n   \n" +
+                    "0: zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestMultipleSemicolonsBetweenRuleSets()
+            {
+                string rules =
+                    "%foo:\n" +
+                    "0: zero;\n" +
+                    ";\n" +
+                    ";;\n" +
+                    "%bar:\n" +
+                    "0: uno;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("uno", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("uno", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestWhitespaceBeforeRuleSet()
+            {
+                string rules =
+                    "%foo:\n" +
+                    "0: zero;\n\n\n\n" +
+                    "      %bar:\n" +
+                    "1: one;\r\n;" +
+                    "2: two;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("two", formatterSettings.formatter.Format(2));
+                Assert.AreEqual("two", formatterSettings.FormatWithIcuNumber(2));
+            }
+
+            [Test]
+            public void TestTrailingSemicolonGarbage()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;\n" +
+                    "1: one;\n" +
+                    " ; ; ;;  ";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestTrailingWhitespacePreservedInsideRule()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero   ;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero   ", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero   ", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestTrailingNewlinePreservedInsideRule()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero   \n;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero   \n", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero   \n", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestEmbeddedNewlineInsideRuleText()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero\nzero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero\nzero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero\nzero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+
+            [Test]
+            public void TestRuleSetBoundaryWhitespace()
+            {
+                string rules =
+                    "%foo:\n" +
+                    "0: zero;\n" +
+                    "\n\n\n" +
+                    "    %bar:\n" +
+                    "0: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestRuleSetBoundaryWhitespaceAfterSemicolon()
+            {
+                string rules =
+                    "%foo:\n" +
+                    "0: zero;\n" +
+                    "     \n" +
+                    "     %bar:\n" +
+                    "0: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestManyEmptyRuleSetSeparators()
+            {
+                string rules =
+                    "%foo:\n" +
+                    "0: zero;\n" +
+                    ";\n" +
+                    ";;\n" +
+                    " ; ; ;\n" +
+                    "%bar:\n" +
+                    "0: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestDoubleSemicolonRuleDelimiter()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;;\n" +
+                    "1: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestTripleSemicolonRuleDelimiter()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;;;\n" +
+                    "1: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestWhitespaceOnlyRuleBetweenSemicolons()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;    ;\n" +
+                    "1: one;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one", formatterSettings.formatter.Format(1));
+                Assert.AreEqual("one", formatterSettings.FormatWithIcuNumber(1));
+            }
+
+            [Test]
+            public void TestWhitespaceBeforeColon()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0 : zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestWhitespaceAfterColon()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0:     zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestLineBreakAfterColon()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0:\n" +
+                    "zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestOptionalTextLineBreak()
+            {
+                string rules =
+                    "%default:\n" +
+                    "20: twenty[\n->>];\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("twenty", formatterSettings.formatter.Format(20));
+                Assert.AreEqual("twenty", formatterSettings.FormatWithIcuNumber(20));
+            }
+
+
+            [Test]
+            public void TestWhitespaceAroundRuleSetReference()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: = %other =;\n" +
+                    "%other:\n" +
+                    "0: zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestLineBreakInsideRuleSetReference()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: =\n%other=;\n" +
+                    "%other:\n" +
+                    "0: zero;\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("zero", formatterSettings.formatter.Format(0));
+                Assert.AreEqual("zero", formatterSettings.FormatWithIcuNumber(0));
+            }
+
+            [Test]
+            public void TestWhitespaceAroundSubstitutionTokens()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;\n" +
+                    "1: one;\n" +
+                    "20: twenty;\n" +
+                    "100: << hundred[ >>];\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one hundred", formatterSettings.formatter.Format(100));
+                Assert.AreEqual("one hundred", formatterSettings.FormatWithIcuNumber(100));
+            }
+
+            [Test]
+            public void TestLineBreakAroundSubstitutionTokens()
+            {
+                string rules =
+                    "%default:\n" +
+                    "0: zero;\n" +
+                    "1: one;\n" +
+                    "20: twenty;\n" +
+                    "100: <<\n hundred[ >>];\n";
+
+                var formatterSettings =
+                    new RbnfFormattterSettings(rules, CultureInfo.InvariantCulture);
+
+                Assert.AreEqual("one\n hundred", formatterSettings.formatter.Format(100));
+                Assert.AreEqual("one\n hundred", formatterSettings.FormatWithIcuNumber(100));
+            }
+        }
     }
 
     internal class RbnfFormattterSettings


### PR DESCRIPTION
Fixes #129.

The `NumberFormatRules` class was creating a `ValueStringBuilder` to mimic the [upstream `stripWhitespace()`](https://github.com/unicode-org/icu/blob/release-60-1/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedNumberFormat.java#L1883-L1934) functionality. However, this was bad for 2 reasons:

1. `ValueStringBuilder.ToString()` wasn't being set to a variable on the stack, so at any point after it returned, it could be collected by the GC.
2. The `StripWhiteSpace()` method created a heap allocation that was effectively doubling the amount of memory required for the operation in the best case.

This PR replaces the `StripWhiteSpace()` method with a `WhiteSpaceStrippingRuleSetTokenEnumerator` ref struct that effectively does:

1. Tokenization (with any number of whitespace characters between the delimiter `;` and lookahead character `%`)
2. Whitespace ignoring
3. Duplicate semicolon ignoring

The inner token string is left unmodified by the `WhiteSpaceStrippingRuleSetTokenEnumerator`, so the `NumberFormatRuleSet.ParseRules()` method was also changed to expect and ignore any empty tokens after stripping leading whitespace.

This also removes the `stripWhiteSpace` parameter from the constructor because upstream this optimization did not exist. Now that we are no longer needlessly allocating double the memory for a rules string to load the rules, this optimization is no longer necessary.

> Note that the equivalent piece of code upstream is the [`RuleBasedNumberFormat.init()` method](https://github.com/unicode-org/icu/blob/release-60-1/icu4j/main/classes/core/src/com/ibm/icu/text/RuleBasedNumberFormat.java#L1696-L1837). The formatting portion of this class was refactored into [.NET-like static (mostly extension) methods](https://github.com/NightOwl888/ICU4N/blob/cd870e6ec2437ad151593ad855dc62622040fbcd/src/ICU4N/Support/FormatNumberRuleBased.generated.cs) that accept `UCultureInfo` or `CultureInfo` as well as a .NET numeric type. `NumberFormatRules` is the rules engine behind the formatting conversion and the plan is to eventually have public [methods that accept it as a parameter](https://github.com/NightOwl888/ICU4N/blob/cd870e6ec2437ad151593ad855dc62622040fbcd/src/ICU4N/Support/FormatNumberRuleBased.cs#L35-L68), which will allow users to specify their own cached rule engine instances that are built from custom rule strings. This PR helps to ensure those rule strings follow the same loose formatting rules that ICU4J allows.