### PR TITLE
Restored APIs from ICU4N.60.1.0-alpha.436 that were removed

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -69,6 +69,7 @@
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_TOBYTEARRAY_BIGENDIAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_STRING_CREATE</DefineConstants>
+    <DefineConstants>$(DefineConstants);FEATURE_STRING_IMPLCIT_TO_READONLYSPAN</DefineConstants>
 
   </PropertyGroup>
 

--- a/src/ICU4N/Impl/BMPSet.cs
+++ b/src/ICU4N/Impl/BMPSet.cs
@@ -146,6 +146,29 @@ namespace ICU4N.Impl
         /// sufficient length for trail unit for each surrogate pair. Handle single surrogates as surrogate code points
         /// as usual in ICU.
         /// </remarks>
+        public int Span(string s, int start, SpanCondition spanCondition,
+            out int outCount)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return Span(s.AsSpan(), start, spanCondition, out outCount);
+        }
+
+        /// <summary>
+        /// Span the initial substring for which each character c has <paramref name="spanCondition"/>==Contains(c). 
+        /// It must be <paramref name="spanCondition"/>==0 or 1.
+        /// </summary>
+        /// <param name="s"></param>
+        /// <param name="start">The start index.</param>
+        /// <param name="spanCondition"></param>
+        /// <param name="outCount">If not null: Receives the number of code points in the span.</param>
+        /// <returns>The limit (exclusive end) of the span.</returns>
+        /// <remarks>
+        /// NOTE: to reduce the overhead of function call to Contains(c), it is manually inlined here. Check for
+        /// sufficient length for trail unit for each surrogate pair. Handle single surrogates as surrogate code points
+        /// as usual in ICU.
+        /// </remarks>
         public int Span(ReadOnlySpan<char> s, int start, SpanCondition spanCondition,
             out int outCount) // ICU4N TODO: API - does it make sense to return length instead of limit to match .NET APIs?
         {
@@ -270,6 +293,20 @@ namespace ICU4N.Impl
             int spanLength = i - start;
             outCount = spanLength - numSupplementary;  // number of code points
             return i;
+        }
+
+        /// <summary>
+        /// Symmetrical with <see cref="Span(string, int, SpanCondition, out int)"/>.
+        /// Span the trailing substring for which each character c has <paramref name="spanCondition"/>==Contains(c). 
+        /// It must be <paramref name="s"/>.Length >= limit and <paramref name="spanCondition"/>==0 or 1.
+        /// </summary>
+        /// <returns>The string index which starts the span (i.e. inclusive).</returns>
+        public int SpanBack(string s, int limit, SpanCondition spanCondition) // ICU4N TODO: API - Change limit to length
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return SpanBack(s.AsSpan(), limit, spanCondition);
         }
 
         /// <summary>

--- a/src/ICU4N/Impl/Locale/AsciiUtil.cs
+++ b/src/ICU4N/Impl/Locale/AsciiUtil.cs
@@ -351,6 +351,14 @@ namespace ICU4N.Impl.Locale
             return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAlpha(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            return IsAlpha(s.AsSpan());
+        }
+
         public static bool IsAlpha(ReadOnlySpan<char> s) // ICU4N specific - renamed from ToAlphaString()
         {
             bool b = true;
@@ -371,6 +379,14 @@ namespace ICU4N.Impl.Locale
             return (c >= '0' && c <= '9');
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsNumeric(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            return IsNumeric(s.AsSpan());
+        }
+
         public static bool IsNumeric(ReadOnlySpan<char> s) // ICU4N specific - renamed from IsNumericString()
         {
             bool b = true;
@@ -389,6 +405,14 @@ namespace ICU4N.Impl.Locale
         public static bool IsAlphaNumeric(char c)
         {
             return IsAlpha(c) || IsNumeric(c);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAlphaNumeric(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            return IsAlphaNumeric(s.AsSpan());
         }
 
         public static bool IsAlphaNumeric(ReadOnlySpan<char> s) // ICU4N specific - renamed from IsAlphaNumericString()

--- a/src/ICU4N/Impl/Locale/LanguageTag.cs
+++ b/src/ICU4N/Impl/Locale/LanguageTag.cs
@@ -740,6 +740,19 @@ namespace ICU4N.Impl.Locale
         //
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsLanguage(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            // language      = 2*3ALPHA            ; shortest ISO 639 code
+            //                 ["-" extlang]       ; sometimes followed by
+            //                                     ;   extended language subtags
+            //               / 4ALPHA              ; or reserved for future use
+            //               / 5*8ALPHA            ; or registered language subtag
+            return (s.Length >= 2) && (s.Length <= 8) && AsciiUtil.IsAlpha(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLanguage(ReadOnlySpan<char> s)
         {
             // language      = 2*3ALPHA            ; shortest ISO 639 code
@@ -751,11 +764,30 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsExtlang(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            // extlang       = 3ALPHA              ; selected ISO 639 codes
+            //                 *2("-" 3ALPHA)      ; permanently reserved
+            return (s.Length == 3) && AsciiUtil.IsAlpha(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsExtlang(ReadOnlySpan<char> s)
         {
             // extlang       = 3ALPHA              ; selected ISO 639 codes
             //                 *2("-" 3ALPHA)      ; permanently reserved
             return (s.Length == 3) && AsciiUtil.IsAlpha(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsScript(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            // script        = 4ALPHA              ; ISO 15924 code
+            return (s.Length == 4) && AsciiUtil.IsAlpha(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -766,12 +798,31 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsRegion(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            // region        = 2ALPHA              ; ISO 3166-1 code
+            //               / 3DIGIT              ; UN M.49 code
+            return ((s.Length == 2) && AsciiUtil.IsAlpha(s))
+                    || ((s.Length == 3) && AsciiUtil.IsNumeric(s));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsRegion(ReadOnlySpan<char> s)
         {
             // region        = 2ALPHA              ; ISO 3166-1 code
             //               / 3DIGIT              ; UN M.49 code
             return ((s.Length == 2) && AsciiUtil.IsAlpha(s))
                     || ((s.Length == 3) && AsciiUtil.IsNumeric(s));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsVariant(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+            return IsVariant(s.AsSpan());
         }
 
         public static bool IsVariant(ReadOnlySpan<char> s)
@@ -791,6 +842,23 @@ namespace ICU4N.Impl.Locale
                         && AsciiUtil.IsAlphaNumeric(s[3]);
             }
             return false;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsExtensionSingleton(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            // singleton     = DIGIT               ; 0 - 9
+            //               / %x41-57             ; A - W
+            //               / %x59-5A             ; Y - Z
+            //               / %x61-77             ; a - w
+            //               / %x79-7A             ; y - z
+
+            return (s.Length == 1)
+                    && AsciiUtil.IsAlpha(s)
+                    && !AsciiUtil.CaseIgnoreMatch(Private_Use, s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -814,10 +882,31 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsExtensionSubtag(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            // extension     = singleton 1*("-" (2*8alphanum))
+            return (s.Length >= 2) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsExtensionSubtag(ReadOnlySpan<char> s)
         {
             // extension     = singleton 1*("-" (2*8alphanum))
             return (s.Length >= 2) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPrivateusePrefix(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            // privateuse    = "x" 1*("-" (1*8alphanum))
+            return (s.Length == 1)
+                    && AsciiUtil.CaseIgnoreMatch(Private_Use, s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -833,6 +922,16 @@ namespace ICU4N.Impl.Locale
         {
             Span<char> buffer = stackalloc char[1] { c };
             return (AsciiUtil.CaseIgnoreMatch(Private_Use, buffer));
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsPrivateuseSubtag(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            // privateuse    = "x" 1*("-" (1*8alphanum))
+            return (s.Length >= 1) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/ICU4N/Impl/Locale/UnicodeLocaleExtension.cs
+++ b/src/ICU4N/Impl/Locale/UnicodeLocaleExtension.cs
@@ -120,10 +120,24 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsAttribute(string s)
+        {
+            // 3*8alphanum
+            return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsAttribute(ReadOnlySpan<char> s)
         {
             // 3*8alphanum
             return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsKey(string s)
+        {
+            // 2alphanum
+            return (s.Length == 2) && AsciiUtil.IsAlphaNumeric(s);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -134,10 +148,23 @@ namespace ICU4N.Impl.Locale
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsTypeSubtag(string s)
+        {
+            // 3*8alphanum
+            return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsTypeSubtag(ReadOnlySpan<char> s)
         {
             // 3*8alphanum
             return (s.Length >= 3) && (s.Length <= 8) && AsciiUtil.IsAlphaNumeric(s);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool IsType(string s)
+        {
+            return IsType(s.AsSpan());
         }
 
         public static bool IsType(ReadOnlySpan<char> s)

--- a/src/ICU4N/Impl/LocaleIDParser.cs
+++ b/src/ICU4N/Impl/LocaleIDParser.cs
@@ -48,6 +48,18 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
         private const char DOT = '.';
         private const char UNDERSCORE = '_';
 
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        public LocaleIDParser(Span<char> initialBuffer, string localeID)
+            : this(initialBuffer, localeID.AsSpan(), false)
+        {
+        }
+
+        public LocaleIDParser(Span<char> initialBuffer, string localeID, bool canonicalize)
+            : this(initialBuffer, localeID.AsSpan(), canonicalize)
+        {
+        }
+#endif
+
         public LocaleIDParser(Span<char> initialBuffer, ReadOnlySpan<char> localeID)
             : this(initialBuffer, localeID, false)
         {
@@ -63,6 +75,16 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
             this.keywords = null;
             this.baseName = ReadOnlySpan<char>.Empty;
         }
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset(string localeID)
+            => Reset(localeID.AsSpan());
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Reset(string localeID, bool canonicalize)
+            => Reset(localeID.AsSpan(), canonicalize);
+#endif
 
         public void Reset(ReadOnlySpan<char> localeID)
         {
@@ -724,6 +746,12 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Impl namespace
                 variant: GetString(ParseVariant())
             );
         }
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+
+        public void SetBaseName(string baseName)
+            => SetBaseName(baseName.AsSpan());
+#endif
 
         public void SetBaseName(ReadOnlySpan<char> baseName)
         {

--- a/src/ICU4N/Impl/LocaleIDs.cs
+++ b/src/ICU4N/Impl/LocaleIDs.cs
@@ -37,6 +37,20 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             return (string[])_languages.Clone();
         }
 
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        /// <summary>
+        /// Returns a three-letter abbreviation for the provided country.  If the provided
+        /// country is empty, returns the empty string.  Otherwise, returns
+        /// an uppercase ISO 3166 3-letter country code.
+        /// </summary>
+        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
+        /// three-letter country abbreviation is not available for this locale.</exception>
+        /// <stable>ICU 3.0</stable>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetThreeLetterISOCountryName(string country)
+            => GetThreeLetterISOCountryName(country.AsSpan());
+#endif
+
         /// <summary>
         /// Returns a three-letter abbreviation for the provided country.  If the provided
         /// country is empty, returns the empty string.  Otherwise, returns
@@ -62,6 +76,23 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             }
             return "";
         }
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        /// <summary>
+        /// Returns a three-letter abbreviation for the language.  If language is
+        /// empty, returns the empty string.  Otherwise, returns
+        /// a lowercase ISO 639-2/T language code.
+        /// </summary>
+        /// <remarks>The ISO 639-2 language codes can be found on-line at
+        /// <a href="ftp://dkuug.dk/i18n/iso-639-2.txt">ftp://dkuug.dk/i18n/iso-639-2.txt</a>.
+        /// </remarks>
+        /// <exception cref="System.Resources.MissingManifestResourceException">Throws <see cref="System.Resources.MissingManifestResourceException"/> if the
+        /// three-letter language abbreviation is not available for this locale.</exception>
+        /// <stable>ICU 3.0</stable>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string GetThreeLetterISOLanguageName(string language)
+            => GetThreeLetterISOLanguageName(language.AsSpan());
+#endif
 
         /// <summary>
         /// Returns a three-letter abbreviation for the language.  If language is
@@ -92,6 +123,12 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
             return "";
         }
 
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ThreeToTwoLetterLanguage(string lang)
+            => ThreeToTwoLetterLanguage(lang.AsSpan());
+#endif
+
         public static string ThreeToTwoLetterLanguage(ReadOnlySpan<char> lang)
         {
             /* convert 3 character code to 2 character code if possible *CWB*/
@@ -109,6 +146,12 @@ namespace ICU4N.Globalization // ICU4N: Moved from ICU4N.Util namespace
 
             return null;
         }
+
+#if !FEATURE_STRING_IMPLCIT_TO_READONLYSPAN
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string ThreeToTwoLetterRegion(string region)
+            => ThreeToTwoLetterRegion(region.AsSpan());
+#endif
 
         public static string ThreeToTwoLetterRegion(ReadOnlySpan<char> region)
         {

--- a/src/ICU4N/Impl/Normalizer2Impl.cs
+++ b/src/ICU4N/Impl/Normalizer2Impl.cs
@@ -504,6 +504,8 @@ namespace ICU4N.Impl
         public ReadOnlySpan<char> AsSpan(int start) => str.AsSpan(start);
         public ReadOnlySpan<char> AsSpan(int start, int length) => str.AsSpan(start, length);
 
+        [CLSCompliant(false)]
+        public char* GetCharsPointer() => str.GetCharsPointer();
         public Span<char> RawChars => str.RawChars;
 
         public bool TryCopyTo(Span<char> destination, out int charsWritten) => str.TryCopyTo(destination, out charsWritten);
@@ -796,6 +798,49 @@ namespace ICU4N.Impl
         public static bool IsSurrogateLead(int c) { return (c & 0x400) == 0; }
 
         #region Equal(ICharSequence, ICharSequence)
+
+        /// <summary>
+        /// Compares two character sequence objects for binary equality.
+        /// </summary>
+        /// <param name="s1">s1 first sequence</param>
+        /// <param name="s2">s2 second sequence</param>
+        /// <returns>true if s1 contains the same text as s2.</returns>
+        public static bool Equal(string s1, string s2)
+        {
+            if (s1 == s2)
+            {
+                return true;
+            }
+            if (s1 is null || s2 is null) return false;
+            // ICU4N: Use optimized equality comparison in System.Memory
+            return System.MemoryExtensions.Equals(s1.AsSpan(), s2.AsSpan(), StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Compares two character sequence objects for binary equality.
+        /// </summary>
+        /// <param name="s1">s1 first sequence</param>
+        /// <param name="s2">s2 second sequence</param>
+        /// <returns>true if s1 contains the same text as s2.</returns>
+        public static bool Equal(string s1, ReadOnlySpan<char> s2)
+        {
+            if (s1 is null) return false;
+            // ICU4N: Use optimized equality comparison in System.Memory
+            return System.MemoryExtensions.Equals(s1.AsSpan(), s2, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Compares two character sequence objects for binary equality.
+        /// </summary>
+        /// <param name="s1">s1 first sequence</param>
+        /// <param name="s2">s2 second sequence</param>
+        /// <returns>true if s1 contains the same text as s2.</returns>
+        public static bool Equal(ReadOnlySpan<char> s1, string s2)
+        {
+            if (s2 is null) return false;
+            // ICU4N: Use optimized equality comparison in System.Memory
+            return System.MemoryExtensions.Equals(s1, s2.AsSpan(), StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Compares two character sequence objects for binary equality.

--- a/src/ICU4N/Impl/TextTrieMap.cs
+++ b/src/ICU4N/Impl/TextTrieMap.cs
@@ -51,11 +51,43 @@ namespace ICU4N.Impl
         /// <param name="text">The text.</param>
         /// <param name="value">The value associated with the text.</param>
         /// <returns></returns>
+        public virtual TextTrieMap<TValue> Put(string text, TValue value)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
+            return Put(text.AsSpan(), value);
+        }
+
+
+        /// <summary>
+        /// Adds the text key and its associated value in this object.
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="value">The value associated with the text.</param>
+        /// <returns></returns>
         public virtual TextTrieMap<TValue> Put(ReadOnlySpan<char> text, TValue value)
         {
             CharEnumerator chitr = new CharEnumerator(text, ignoreCase);
             root.Add(chitr, value);
             return this;
+        }
+
+        /// <summary>
+        /// Gets an enumerator of the values associated with the
+        /// longest prefix matching string key.
+        /// </summary>
+        /// <param name="text">The text to be matched with prefixes.</param>
+        /// <returns>
+        /// An enumerator of the values associated with
+        /// the longest prefix matching matching key, or <c>null</c>
+        /// if no matching entry is found.
+        /// </returns>
+        public virtual IEnumerator<TValue> Get(string text)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
+
+            return Get(text.AsSpan());
         }
 
         /// <summary>
@@ -75,12 +107,28 @@ namespace ICU4N.Impl
 
         // ICU4N specific: Eliminatd Get(ICharSequence text, int start, int[] matchLen) because we can slice a ReadOnlySpan<char>
 
+        public virtual IEnumerator<TValue> Get(string text, out int matchLength)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
+
+            return Get(text.AsSpan(), out matchLength);
+        }
+
         public virtual IEnumerator<TValue> Get(ReadOnlySpan<char> text, out int matchLength)
         {
             LongestMatchHandler<TValue> handler = new LongestMatchHandler<TValue>();
             Find(text, handler);
             matchLength = handler.MatchLength;
             return handler.Matches;
+        }
+
+        public virtual void Find(string text, IResultHandler<TValue> handler)
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause.
+
+            Find(text.AsSpan(), handler);
         }
 
         public virtual void Find(ReadOnlySpan<char> text, IResultHandler<TValue> handler)

--- a/src/ICU4N/Impl/Trie2.cs
+++ b/src/ICU4N/Impl/Trie2.cs
@@ -508,6 +508,21 @@ namespace ICU4N.Impl
         /// <param name="text">A text string to be iterated over.</param>
         /// <param name="index">The starting iteration position within the input text.</param>
         /// <returns>The <see cref="CharSequenceEnumerator"/>.</returns>
+        public virtual CharSequenceEnumerator GetCharSequenceEnumerator(string text, int index) // ICU4N specific
+        {
+            if (text is null)
+                throw new ArgumentNullException(nameof(text)); // ICU4N: Added guard clause
+
+            return new CharSequenceEnumerator(this, text.AsSpan(), index);
+        }
+
+        /// <summary>
+        /// Create an enumerator that will produce the values from the <see cref="Trie2"/> for
+        /// the sequence of code points in an input text.
+        /// </summary>
+        /// <param name="text">A text string to be iterated over.</param>
+        /// <param name="index">The starting iteration position within the input text.</param>
+        /// <returns>The <see cref="CharSequenceEnumerator"/>.</returns>
         public virtual CharSequenceEnumerator GetCharSequenceEnumerator(ReadOnlySpan<char> text, int index)
         {
             return new CharSequenceEnumerator(this, text, index);

--- a/src/ICU4N/Impl/UCharacterName.cs
+++ b/src/ICU4N/Impl/UCharacterName.cs
@@ -108,6 +108,16 @@ namespace ICU4N.Impl
         /// <param name="choice">Selector to indicate if argument name is a Unicode 1.0 or the most current version.</param>
         /// <param name="name">The name to search for.</param>
         /// <returns>Code point.</returns>
+        public int GetCharFromName(UCharacterNameChoice choice, string? name)
+            => GetCharFromName(choice, name.AsSpan());
+
+        /// <summary>
+        /// Find a character by its name and return its code point value
+        /// 
+        /// </summary>
+        /// <param name="choice">Selector to indicate if argument name is a Unicode 1.0 or the most current version.</param>
+        /// <param name="name">The name to search for.</param>
+        /// <returns>Code point.</returns>
         public int GetCharFromName(UCharacterNameChoice choice, ReadOnlySpan<char> name)
         {
             // checks for illegal arguments

--- a/src/ICU4N/Impl/UPropertyAliases.cs
+++ b/src/ICU4N/Impl/UPropertyAliases.cs
@@ -426,9 +426,43 @@ namespace ICU4N.Impl
         /// If the property name is not known, this method returns
         /// <see cref="UPropertyConstants.Undefined"/>.
         /// </summary>
+        public int GetPropertyEnum(string alias)
+        {
+            return GetPropertyOrValueEnum(0, alias);
+        }
+
+        /// <summary>
+        /// Returns a property enum given one of its property names.
+        /// If the property name is not known, this method returns
+        /// <see cref="UPropertyConstants.Undefined"/>.
+        /// </summary>
         public int GetPropertyEnum(ReadOnlySpan<char> alias)
         {
             return GetPropertyOrValueEnum(0, alias);
+        }
+
+        /// <summary>
+        /// Returns a value enum given a property enum and one of its value names.
+        /// </summary>
+        /// <seealso cref="TryGetPropertyValueEnum(UProperty, string, out int)"/>
+        public int GetPropertyValueEnum(UProperty property, string alias)
+        {
+            int valueMapIndex = FindProperty((int)property);
+            if (valueMapIndex == 0)
+            {
+                throw new ArgumentException(
+                        "Invalid property enum " + property + " (0x" + string.Format("{0:x2}", (int)property) + ")");
+            }
+            valueMapIndex = valueMaps[valueMapIndex + 1];
+            if (valueMapIndex == 0)
+            {
+                throw new ArgumentException(
+                        "Property " + property + " (0x" + string.Format("{0:x2}", (int)property) +
+                        ") does not have named values");
+            }
+            // valueMapIndex is the start of the property's valueMap,
+            // where the first word is the BytesTrie offset.
+            return GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
         }
 
         /// <summary>
@@ -453,6 +487,33 @@ namespace ICU4N.Impl
             // valueMapIndex is the start of the property's valueMap,
             // where the first word is the BytesTrie offset.
             return GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
+        }
+
+        /// <summary>
+        /// Returns a value enum given a property enum and one of its value names.
+        /// </summary>
+        /// <seealso cref="GetPropertyValueEnum(UProperty, string)"/>
+        public bool TryGetPropertyValueEnum(UProperty property, string alias, out int result)
+        {
+#pragma warning disable 612, 618
+            result = (int)UPropertyConstants.Undefined;
+#pragma warning restore 612, 618
+            int valueMapIndex = FindProperty((int)property);
+            if (valueMapIndex == 0)
+            {
+                return false;
+            }
+            valueMapIndex = valueMaps[valueMapIndex + 1];
+            if (valueMapIndex == 0)
+            {
+                return false;
+            }
+            // valueMapIndex is the start of the property's valueMap,
+            // where the first word is the BytesTrie offset.
+            result = GetPropertyOrValueEnum(valueMaps[valueMapIndex], alias);
+#pragma warning disable 612, 618
+            return result != (int)UPropertyConstants.Undefined;
+#pragma warning restore 612, 618
         }
 
         /// <summary>

--- a/src/ICU4N/Impl/UnicodeSetStringSpan.cs
+++ b/src/ICU4N/Impl/UnicodeSetStringSpan.cs
@@ -393,6 +393,21 @@ namespace ICU4N.Impl
         /// <param name="start">The start index that the span begins.</param>
         /// <param name="spanCondition">The span condition.</param>
         /// <returns>The limit (exclusive end) of the span.</returns>
+        public int Span(string s, int start, SpanCondition spanCondition)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return Span(s.AsSpan(), start, spanCondition);
+        }
+
+        /// <summary>
+        /// Spans a string.
+        /// </summary>
+        /// <param name="s">The string to be spanned.</param>
+        /// <param name="start">The start index that the span begins.</param>
+        /// <param name="spanCondition">The span condition.</param>
+        /// <returns>The limit (exclusive end) of the span.</returns>
         public int Span(ReadOnlySpan<char> s, int start, SpanCondition spanCondition)
         {
             if (spanCondition == SpanCondition.NotContained)
@@ -624,6 +639,29 @@ namespace ICU4N.Impl
         /// <param name="spanCondition">The span condition.</param>
         /// <param name="outCount">The count.</param>
         /// <returns>The limit (exclusive end) of the span.</returns>
+        public int SpanAndCount(string s, int start, SpanCondition spanCondition,
+            out int outCount) // ICU4N TODO: API - Would this be more useful if we returned length instead of limit?
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return SpanAndCount(s.AsSpan(), start, spanCondition, out outCount);
+        }
+
+        /// <summary>
+        /// Spans a string and counts the smallest number of set elements on any path across the span.
+        /// </summary>
+        /// <remarks>
+        /// For proper counting, we cannot ignore strings that are fully contained in code point spans.
+        /// <para/>
+        /// If the set does not have any fully-contained strings, then we could optimize this
+        /// like Span(), but such sets are likely rare, and this is at least still linear.
+        /// </remarks>
+        /// <param name="s">The string to be spanned.</param>
+        /// <param name="start">The start index that the span begins.</param>
+        /// <param name="spanCondition">The span condition.</param>
+        /// <param name="outCount">The count.</param>
+        /// <returns>The limit (exclusive end) of the span.</returns>
         public int SpanAndCount(ReadOnlySpan<char> s, int start, SpanCondition spanCondition,
             out int outCount) // ICU4N TODO: API - Would this be more useful if we returned length instead of limit?
         {
@@ -721,6 +759,21 @@ namespace ICU4N.Impl
                 outCount = count;
                 return pos;
             }
+        }
+
+        /// <summary>
+        /// Span a string backwards.
+        /// </summary>
+        /// <param name="s">The string to be spanned.</param>
+        /// <param name="length"></param>
+        /// <param name="spanCondition">The span condition</param>
+        /// <returns>The string index which starts the span (i.e. inclusive).</returns>
+        public int SpanBack(string s, int length, SpanCondition spanCondition)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return SpanBack(s.AsSpan(), length, spanCondition);
         }
 
         /// <summary>

--- a/src/ICU4N/Impl/Utility.cs
+++ b/src/ICU4N/Impl/Utility.cs
@@ -690,6 +690,18 @@ namespace ICU4N.Impl
         /// Convert a string to comma-separated groups of 4 hex uppercase
         /// digits.  E.g., hex('ab') => "0041,0042".
         /// </summary>
+        public static string Hex(string s)
+        {
+            if (s is null)
+                throw new ArgumentNullException(nameof(s));
+
+            return Hex(s.AsSpan());
+        }
+
+        /// <summary>
+        /// Convert a string to comma-separated groups of 4 hex uppercase
+        /// digits.  E.g., hex('ab') => "0041,0042".
+        /// </summary>
         public static string Hex(ReadOnlySpan<char> s)
         {
             ValueStringBuilder sb = new ValueStringBuilder(stackalloc char[CharStackBufferSize]);

--- a/src/ICU4N/Support/Text/ValueStringBuilder.cs
+++ b/src/ICU4N/Support/Text/ValueStringBuilder.cs
@@ -108,6 +108,18 @@ namespace ICU4N.Text
             return ref MemoryMarshal.GetReference(_chars);
         }
 
+        // ICU4N: Added this to allow inserting one ValueStringBuilder to another
+        // without the compiler complaining about scope. The scoped keyword on 
+        // the ReadOnlySpan<char> parameter of Insert(int, ReadOnlySpan<char>) would
+        // also work, but since that requires LangVersion=>11.0 and that causes more compiler
+        // errors, we are going with this for now. Note we also marked this struct unsafe
+        // just like NumberBuffer is (it wasn't that way originally).
+        public unsafe char* GetCharsPointer()
+        {
+            // This is safe to do since we are a ref struct
+            return (char*)Unsafe.AsPointer(ref _chars[0]);
+        }
+
         public ref char this[int index]
         {
             get


### PR DESCRIPTION
Restored APIs from ICU4N.60.1.0-alpha.436 that were removed (mostly in #120), which were breaking changes from the ICU4N.60.1.0-alpha.436 release.

This is in preparation of a binary compatible release for Lucene.NET 4.8.0-beta-00017 with all of the latest updates and patches. This change will be reverted prior to a future release.