### PR TITLE
Added `net10.0` target + tests

### DIFF
--- a/.build/TestTargetFramework.props
+++ b/.build/TestTargetFramework.props
@@ -10,6 +10,7 @@
     <!--<TargetFramework>net6.0</TargetFramework>-->
     <!--<TargetFramework>net8.0</TargetFramework>-->
     <!--<TargetFramework>net9.0</TargetFramework>-->
+    <!--<TargetFramework>net10.0</TargetFramework>-->
     <TestAllTargetFrameworks>true</TestAllTargetFrameworks>
 
     <!-- Allow the build script to pass in the test frameworks to build for.
@@ -19,6 +20,7 @@
     <!-- Test Client to DLL target works as follows:
 
       Test Client       | Target Under Test
+      net10.0           | net10.0
       net9.0            | net9.0
       net8.0            | net8.0
       net6.0            | netstandard2.0
@@ -27,7 +29,7 @@
       net47             | net40
 
     -->
-    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true'">net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And '$(IsLegacyVisualStudioVersion)' != 'true'">$(TargetFrameworks);net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(TestAllTargetFrameworks)' == 'true' And $([MSBuild]::IsOsPlatform('Windows')) And '$(IsLegacyVisualStudioVersion)' != 'true'">$(TargetFrameworks);net48;net472;net47</TargetFrameworks>
     <TargetFramework Condition=" '$(TargetFrameworks)' != '' "></TargetFramework>

--- a/.build/azure-templates/publish-test-results-for-target-frameworks.yml
+++ b/.build/azure-templates/publish-test-results-for-target-frameworks.yml
@@ -26,6 +26,16 @@ steps:
 
 - template: publish-test-results.yml
   parameters:
+    framework: 'net10.0'
+    testProjectName: '${{ parameters.testProjectName }}'
+    osName: '${{ parameters.osName }}'
+    testPlatform: '${{ parameters.testPlatform }}'
+    testResultsFormat: '${{ parameters.testResultsFormat }}'
+    testResultsArtifactName: '${{ parameters.testResultsArtifactName }}'
+    testResultsFileName: '${{ parameters.testResultsFileName }}'
+
+- template: publish-test-results.yml
+  parameters:
     framework: 'net9.0'
     testProjectName: '${{ parameters.testProjectName }}'
     osName: '${{ parameters.osName }}'

--- a/.build/azure-templates/run-tests-on-os.yml
+++ b/.build/azure-templates/run-tests-on-os.yml
@@ -56,6 +56,23 @@ steps:
     sdkVersion: '$(DotNetSdkVersion)'
     performMultiLevelLookup: '$(PerformMultiLevelLookup)'
 
+    # Hack: .NET 8+ no longer installs the x86 bits and they must be installed separately. However, it is not
+    # trivial to get it into the path and to get it to pass the minimum SDK version check in runbuild.ps1.
+    # So, we install it afterward and set the environment variable so the above SDK can delegate to it.
+    # This code only works on Windows.
+- pwsh: |
+    $sdkVersion = '$(DotNetSdkVersion)'
+    $architecture = '${{ parameters.vsTestPlatform }}'
+    $installScriptPath = "${env:AGENT_TEMPDIRECTORY}/dotnet-install.ps1"
+    $installScriptUrl = "https://raw.githubusercontent.com/dotnet/install-scripts/main/src/dotnet-install.ps1"
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-WebRequest $installScriptUrl -OutFile $installScriptPath -TimeoutSec 60
+    $installPath = "${env:ProgramFiles(x86)}/dotnet"
+    & $installScriptPath -Version $sdkVersion -Architecture $architecture -InstallDir $installPath
+    Write-Host "##vso[task.setvariable variable=DOTNET_ROOT_X86;]$installPath"
+  displayName: 'Use .NET SDK $(DotNetSdkVersion) (x86)'
+  condition: and(succeeded(), contains('${{ parameters.testTargetFrameworks }}', 'net10.'), eq('${{ parameters.vsTestPlatform }}', 'x86'))
+
 - task: UseDotNet@2
   displayName: 'Use .NET SDK 9.0.313'
   inputs:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,16 +3,22 @@
   <Import Project="$(MSBuildThisFileDirectory)/.build/dependencies.props" Condition="Exists('$(MSBuildThisFileDirectory)/.build/dependencies.props')" />
   <Import Project="$(MSBuildThisFileDirectory)/.build/nowarn.props" Condition="Exists('$(MSBuildThisFileDirectory)/.build/nowarn.props')" />
 
-  
+  <!--Features in .NET 10+ only-->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net10.')) ">
+
+    <DefineConstants>$(DefineConstants);FEATURE_ISET_ASREADONLY</DefineConstants>
+
+  </PropertyGroup>
+
   <!--Features in .NET 9+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_STARTSWITH_ENDSWITH_ELEMENT</DefineConstants>
 
   </PropertyGroup>
 
   <!--Features in .NET 7+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_IDICTIONARY_ASREADONLY</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_ILIST_ASREADONLY</DefineConstants>
@@ -21,21 +27,21 @@
   </PropertyGroup>
   
   <!--Features in .NET 6+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_SPANFORMATTABLE</DefineConstants>
 
   </PropertyGroup>
   
   <!--Features in .NET 5+ only-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
     
     <DefineConstants>$(DefineConstants);FEATURE_HALF</DefineConstants>
 
   </PropertyGroup>
 
   <!-- Features in .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_CONTAINS_T</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_MEMORYEXTENSIONS_LASTINDEXOF_COMPARISONTYPE</DefineConstants>
@@ -47,7 +53,7 @@
   </PropertyGroup>
 
   <!--Features in .NET Standard 2.x or .NET Core-->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('netstandard')) Or $(TargetFramework.StartsWith('netcoreapp')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_APPCONTEXT_BASEDIRECTORY</DefineConstants>
@@ -63,8 +69,8 @@
 
 
 
-  <!-- Features in .NET Standard 2.1, .NET Core 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or ($(TargetFramework.StartsWith('netcoreapp2.')) And '$(TargetFramework)' != 'netcoreapp2.0') Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <!-- Features in .NET Standard 2.1, .NET Core 2.1, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, .NET 9.x, and .NET 10.x -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or ($(TargetFramework.StartsWith('netcoreapp2.')) And '$(TargetFramework)' != 'netcoreapp2.0') Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_BIGINTEGER_TOBYTEARRAY_BIGENDIAN</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_RANDOMNUMBERGENERATOR_FILL_SPAN</DefineConstants>
@@ -82,9 +88,9 @@
 
   </PropertyGroup>
 
-  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x -->
+  <!-- Features in .NET Framework 4.5+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, .NET 9.x, and .NET 10.x -->
   <!-- These features are not in .NET Framework 4.0 or .NET Framework 4.7 (the target framework we use for testing .NET Framework 4.0) -->
-  <PropertyGroup Condition=" ('$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net47' And $(TargetFramework.StartsWith('net4'))) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+  <PropertyGroup Condition=" ('$(TargetFramework)' != 'net40' And '$(TargetFramework)' != 'net47' And $(TargetFramework.StartsWith('net4'))) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_DEFAULTTHREADCURRENTCULTURE</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_EXCEPTION_HRESULT</DefineConstants>
@@ -101,8 +107,8 @@
     
   </PropertyGroup>
 
-    <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, and .NET 9.x -->
-  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) ">
+    <!-- Features in .NET Framework 4+, .NET Standard 2.x, .NET Core 2.x, .NET Core 3.x, .NET 5.x, .NET 6.x, .NET 7.x, .NET 8.x, .NET 9.x, and .NET 10.x -->
+  <PropertyGroup Condition=" $(TargetFramework.StartsWith('net4')) Or $(TargetFramework.StartsWith('netstandard2.')) Or $(TargetFramework.StartsWith('netcoreapp2.')) Or $(TargetFramework.StartsWith('netcoreapp3.')) Or $(TargetFramework.StartsWith('net5.')) Or $(TargetFramework.StartsWith('net6.')) Or $(TargetFramework.StartsWith('net7.')) Or $(TargetFramework.StartsWith('net8.')) Or $(TargetFramework.StartsWith('net9.')) Or $(TargetFramework.StartsWith('net10.')) ">
 
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_GETCULTURES</DefineConstants>
     <DefineConstants>$(DefineConstants);FEATURE_CULTUREINFO_IETFLANGUAGETAG</DefineConstants>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ name: 'vNext$(rev:.r)' # Format for build number (will be overridden)
 
 variables:
 - name: TestTargetFrameworks
-  value: 'net9.0;net8.0;net6.0;net48;net472;net47'
+  value: 'net10.0;net9.0;net8.0;net6.0;net48;net472;net47'
 - name: DotNetSDKVersion
   value: '10.0.202'
 - name: BinaryArtifactName
@@ -350,6 +350,56 @@ stages:
       parameters:
         osName: $(osName)
         testTargetFrameworks: 'net9.0'
+        vsTestPlatform: 'x86'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net10_0_x64
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        Linux:
+          osName: 'Linux'
+          imageName: 'ubuntu-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+        macOS:
+          osName: 'macOS'
+          imageName: 'macOS-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net10.0,x64 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFrameworks: 'net10.0'
+        vsTestPlatform: 'x64'
+        testResultsArtifactName: '$(TestResultsArtifactName)'
+        maximumAllowedFailures: $(maximumAllowedFailures)
+        dotNetSdkVersion: '$(DotNetSDKVersion)'
+
+  - job: Test_net10_0_x86 # Only run if explicitly enabled with RunX86Tests
+    condition: and(succeeded(), ne(variables['RunTests'], 'false'), eq(variables['RunX86Tests'], 'true'))
+    strategy:
+      matrix:
+        Windows:
+          osName: 'Windows'
+          imageName: 'windows-latest'
+          maximumAllowedFailures: 0 # Maximum allowed failures for a successful build
+    displayName: 'Test net10.0,x86 on'
+    pool:
+      vmImage: $(imageName)
+    steps:
+    - template: '.build/azure-templates/run-tests-on-os.yml'
+      parameters:
+        osName: $(osName)
+        testTargetFrameworks: 'net10.0'
         vsTestPlatform: 'x86'
         testResultsArtifactName: '$(TestResultsArtifactName)'
         maximumAllowedFailures: $(maximumAllowedFailures)

--- a/src/ICU4N.Collation/ICU4N.Collation.csproj
+++ b/src/ICU4N.Collation/ICU4N.Collation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->

--- a/src/ICU4N.Collation/Text/AlphabeticIndex.cs
+++ b/src/ICU4N.Collation/Text/AlphabeticIndex.cs
@@ -1120,11 +1120,7 @@ namespace ICU4N.Text
                 {
                     bucket.DisplayIndex = displayIndex++;
                 }
-#if FEATURE_ILIST_ASREADONLY
-                immutableVisibleList = System.Collections.Generic.CollectionExtensions.AsReadOnly(publicBucketList);
-#else
                 immutableVisibleList = publicBucketList.AsReadOnly();
-#endif
             }
 
             internal int BucketCount => immutableVisibleList.Count;

--- a/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
+++ b/src/ICU4N.CurrencyData/ICU4N.CurrencyData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->

--- a/src/ICU4N.CurrencyData/Impl/ICUCurrencyMetaInfo.cs
+++ b/src/ICU4N.CurrencyData/Impl/ICUCurrencyMetaInfo.cs
@@ -1,6 +1,6 @@
-﻿using ICU4N.Text;
+﻿using ICU4N;
+using ICU4N.Text;
 using ICU4N.Util;
-using J2N.Collections.Generic.Extensions;
 using System.Collections.Generic;
 
 namespace ICU4N.Impl
@@ -222,11 +222,7 @@ namespace ICU4N.Impl
 
             internal IList<T> ToList()
             {
-#if FEATURE_ILIST_ASREADONLY
-                return System.Collections.Generic.CollectionExtensions.AsReadOnly(list);
-#else
                 return list.AsReadOnly();
-#endif
             }
         }
 
@@ -245,11 +241,7 @@ namespace ICU4N.Impl
 
             public IList<CurrencyInfo> ToList()
             {
-#if FEATURE_ILIST_ASREADONLY
-                return System.Collections.Generic.CollectionExtensions.AsReadOnly(result);
-#else
                 return result.AsReadOnly();
-#endif
             }
 
             public int Collects => Everything;

--- a/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
+++ b/src/ICU4N.LanguageData/ICU4N.LanguageData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->

--- a/src/ICU4N.RegionData/ICU4N.RegionData.csproj
+++ b/src/ICU4N.RegionData/ICU4N.RegionData.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->

--- a/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
+++ b/src/ICU4N.TestFramework/ICU4N.TestFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework></TargetFramework>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <CLSCompliant>false</CLSCompliant>

--- a/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
+++ b/src/ICU4N.Transliterator/ICU4N.Transliterator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
     <RootNamespace>ICU4N</RootNamespace>
     <!-- This project is only for organizational purposes-->

--- a/src/ICU4N/ICU4N.csproj
+++ b/src/ICU4N/ICU4N.csproj
@@ -4,7 +4,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(IsLegacyVisualStudioVersion)' != 'true' ">$(TargetFrameworks);netstandard2.0;net462;net451;net40</TargetFrameworks>
 
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
@@ -30,6 +30,7 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ICU4N.Collation" />
     <InternalsVisibleTo Include="ICU4N.Transliterator" />
+    <InternalsVisibleTo Include="ICU4N.CurrencyData"/>
     
     <InternalsVisibleTo Include="ICU4N.TestFramework" />
     <InternalsVisibleTo Include="ICU4N.Tests" />
@@ -48,6 +49,10 @@
 
   <ItemGroup>
     <PackageReference Include="J2N" Version="$(J2NPackageReferenceVersion)" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(MicrosoftExtensionsCachingMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net9.0' ">

--- a/src/ICU4N/Impl/CurrencyData.cs
+++ b/src/ICU4N/Impl/CurrencyData.cs
@@ -144,19 +144,9 @@ namespace ICU4N.Impl
             return fallback ? isoCode : null;
         }
 
-        public override IDictionary<string, string> SymbolMap
-#if FEATURE_IDICTIONARY_ASREADONLY
-            => System.Collections.Generic.CollectionExtensions.AsReadOnly(new Dictionary<string, string>());
-#else
-            => new Dictionary<string, string>().AsReadOnly();
-#endif
+        public override IDictionary<string, string> SymbolMap => Collection.EmptyDictionary<string, string>();
 
-        public override IDictionary<string, string> NameMap
-#if FEATURE_IDICTIONARY_ASREADONLY
-            => System.Collections.Generic.CollectionExtensions.AsReadOnly(new Dictionary<string, string>());
-#else
-            => new Dictionary<string, string>().AsReadOnly();
-#endif
+        public override IDictionary<string, string> NameMap => Collection.EmptyDictionary<string, string>();
 
         public override UCultureInfo UCulture
             => UCultureInfo.InvariantCulture;
@@ -165,11 +155,7 @@ namespace ICU4N.Impl
         {
             if (fallback)
             {
-#if FEATURE_IDICTIONARY_ASREADONLY
-                return System.Collections.Generic.CollectionExtensions.AsReadOnly(new Dictionary<string, string>());
-#else
-                return new Dictionary<string, string>().AsReadOnly();
-#endif
+                return Collection.EmptyDictionary<string, string>();
             }
             return null;
         }

--- a/src/ICU4N/Impl/ICUService.cs
+++ b/src/ICU4N/Impl/ICUService.cs
@@ -448,11 +448,7 @@ namespace ICU4N.Impl
                             IServiceFactory f = factories[i];
                             f.UpdateVisibleIDs(mutableMap);
                         }
-#if FEATURE_IDICTIONARY_ASREADONLY
-                        return System.Collections.Generic.CollectionExtensions.AsReadOnly(mutableMap);
-#else
                         return mutableMap.AsReadOnly();
-#endif
                     }
                     finally
                     {
@@ -596,11 +592,7 @@ namespace ICU4N.Impl
                             dncache[f.GetDisplayName(id, locale)] = id;
                         }
 
-#if FEATURE_IDICTIONARY_ASREADONLY
-                        dncache = System.Collections.Generic.CollectionExtensions.AsReadOnly(dncache);
-#else
                         dncache = dncache.AsReadOnly();
-#endif
                         dnref = new LocaleRef(dncache, locale, com);
                     }
                     else
@@ -614,11 +606,7 @@ namespace ICU4N.Impl
             ICUServiceKey matchKey = CreateKey(matchID);
             if (matchKey == null)
             {
-#if FEATURE_IDICTIONARY_ASREADONLY
-                return System.Collections.Generic.CollectionExtensions.AsReadOnly(dncache);
-#else
-                return dncache.AsReadOnly();
-#endif
+                return dncache;
             }
 
             // ICU4N: Rather than copying and then removing the items (which isn't allowed with

--- a/src/ICU4N/Impl/Locale/KeyTypeData.cs
+++ b/src/ICU4N/Impl/Locale/KeyTypeData.cs
@@ -444,11 +444,7 @@ namespace ICU4N.Impl.Locale
                         KEYMAP[AsciiUtil.ToLower(bcpKeyId)] = keyData;
                     }
                 }
-#if FEATURE_IDICTIONARY_ASREADONLY
-                BCP47_KEYS = System.Collections.Generic.CollectionExtensions.AsReadOnly(_Bcp47Keys);
-#else
                 BCP47_KEYS = _Bcp47Keys.AsReadOnly();
-#endif
             }
         }
 
@@ -498,11 +494,7 @@ namespace ICU4N.Impl.Locale
                 }
             }
             DEPRECATED_KEYS = _deprecatedKeys.AsReadOnly();
-#if FEATURE_IDICTIONARY_ASREADONLY
-            VALUE_TYPES = System.Collections.Generic.CollectionExtensions.AsReadOnly(_valueTypes);
-#else
             VALUE_TYPES = _valueTypes.AsReadOnly();
-#endif
         }
 
         /** Reads:
@@ -541,11 +533,7 @@ namespace ICU4N.Impl.Locale
                     _deprecatedKeyTypes[key2] = _deprecatedTypes.AsReadOnly();
                 }
             }
-#if FEATURE_IDICTIONARY_ASREADONLY
-            DEPRECATED_KEY_TYPES = System.Collections.Generic.CollectionExtensions.AsReadOnly(_deprecatedKeyTypes);
-#else
             DEPRECATED_KEY_TYPES = _deprecatedKeyTypes.AsReadOnly();
-#endif
         }
 
 

--- a/src/ICU4N/Impl/Locale/LanguageTag.cs
+++ b/src/ICU4N/Impl/Locale/LanguageTag.cs
@@ -708,30 +708,15 @@ namespace ICU4N.Impl.Locale
 
         public string Language => _language;
 
-        public IList<string> Extlangs
-#if FEATURE_ILIST_ASREADONLY
-            => System.Collections.Generic.CollectionExtensions.AsReadOnly(_extlangs);
-#else
-            => _extlangs.AsReadOnly();
-#endif
+        public IList<string> Extlangs => _extlangs.AsReadOnly();
 
         public string Script => _script;
 
         public string Region => _region;
 
-        public IList<string> Variants
-#if FEATURE_ILIST_ASREADONLY
-            => System.Collections.Generic.CollectionExtensions.AsReadOnly(_variants);
-#else
-            => _variants.AsReadOnly();
-#endif
+        public IList<string> Variants => _variants.AsReadOnly();
 
-        public IList<string> Extensions
-#if FEATURE_ILIST_ASREADONLY
-            => System.Collections.Generic.CollectionExtensions.AsReadOnly(_extensions);
-#else
-            => _extensions.AsReadOnly();
-#endif
+        public IList<string> Extensions => _extensions.AsReadOnly();
 
         public string PrivateUse => _privateuse;
 

--- a/src/ICU4N/Impl/PluralRulesLoader.cs
+++ b/src/ICU4N/Impl/PluralRulesLoader.cs
@@ -592,11 +592,7 @@ namespace ICU4N.Impl
                 tempLocaleIdToPluralRanges[locale] = pr!;
             }
             // now make whole thing immutable
-#if FEATURE_IDICTIONARY_ASREADONLY
-            return System.Collections.Generic.CollectionExtensions.AsReadOnly(tempLocaleIdToPluralRanges);
-#else
             return tempLocaleIdToPluralRanges.AsReadOnly();
-#endif
         }
     }
 }

--- a/src/ICU4N/Impl/StandardPlural.cs
+++ b/src/ICU4N/Impl/StandardPlural.cs
@@ -46,19 +46,10 @@ namespace ICU4N.Impl
     /// </summary>
     public static partial class StandardPluralUtil
     {
-        private static readonly IList<StandardPlural> values =
-#if FEATURE_ILIST_ASREADONLY
-            System.Collections.Generic.CollectionExtensions.AsReadOnly(Enum.GetValues<StandardPlural>());
-#else
-            ((StandardPlural[])Enum.GetValues(typeof(StandardPlural))).AsReadOnly();
-#endif
+        private static readonly IList<StandardPlural> values = Enum.GetValues<StandardPlural>().AsReadOnly();
 
         private static readonly string[] keywords =
-#if FEATURE_ILIST_ASREADONLY
             Enum.GetNames<StandardPlural>()
-#else
-            ((string[])Enum.GetNames(typeof(StandardPlural)))
-#endif
             .Select(n => n.ToLowerInvariant()).ToArray();
 
         /// <summary>

--- a/src/ICU4N/Support/Collections/Collection.cs
+++ b/src/ICU4N/Support/Collections/Collection.cs
@@ -1,5 +1,4 @@
-﻿using J2N.Collections.Generic.Extensions;
-using J2N.Collections.ObjectModel;
+﻿using J2N.Collections.ObjectModel;
 using JCG = J2N.Collections.Generic;
 
 namespace ICU4N.Support.Collections

--- a/src/ICU4N/Support/Compatibility/AsReadOnlyExtensions.cs
+++ b/src/ICU4N/Support/Compatibility/AsReadOnlyExtensions.cs
@@ -1,0 +1,45 @@
+﻿using JCG = J2N.Collections.Generic;
+using SCG = System.Collections.Generic;
+
+namespace ICU4N
+{
+    /// <summary>
+    /// Since both .NET and J2N supply <c>AsReadOnly()</c> extension methods with the same signature for collections,
+    /// they cause ambiguous matches when importing both namespaces. This class is to resolve which of
+    /// those methods to use when both are available.
+    /// </summary>
+    internal static class AsReadOnlyExtensions
+    {
+        public static SCG.ISet<T> AsReadOnly<T>(this SCG.ISet<T> set)
+        {
+#if FEATURE_ISET_ASREADONLY
+            return SCG.CollectionExtensions.AsReadOnly(set);
+#else
+            return JCG.Extensions.SetExtensions.AsReadOnly(set);
+#endif
+        }
+
+        public static SCG.IDictionary<TKey, TValue> AsReadOnly<TKey, TValue>(this SCG.IDictionary<TKey, TValue> dictionary)
+        {
+#if FEATURE_IDICTIONARY_ASREADONLY
+            return SCG.CollectionExtensions.AsReadOnly(dictionary);
+#else
+            return JCG.Extensions.DictionaryExtensions.AsReadOnly(dictionary);
+#endif
+        }
+
+        public static SCG.IList<T> AsReadOnly<T>(this SCG.IList<T> list)
+        {
+#if FEATURE_ILIST_ASREADONLY
+            return SCG.CollectionExtensions.AsReadOnly(list);
+#else
+            return JCG.Extensions.ListExtensions.AsReadOnly(list);
+#endif
+        }
+
+        public static SCG.ICollection<T> AsReadOnly<T>(this SCG.ICollection<T> collection)
+        {
+            return JCG.Extensions.CollectionExtensions.AsReadOnly(collection);
+        }
+    }
+}

--- a/src/ICU4N/Support/Compatibility/EnumCompatibilityExtensions.cs
+++ b/src/ICU4N/Support/Compatibility/EnumCompatibilityExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ICU4N
+{
+    public static class EnumCompatibilityExtensions
+    {
+        extension(System.Enum)
+        {
+            public static TEnum[] GetValues<TEnum>()
+                where TEnum : struct, Enum
+                => (TEnum[])Enum.GetValues(typeof(TEnum));
+
+            public static string[] GetNames<TEnum>()
+                where TEnum : struct, Enum
+                => Enum.GetNames(typeof(TEnum));
+        }
+    }
+}

--- a/src/ICU4N/Text/MessagePatternUtil.cs
+++ b/src/ICU4N/Text/MessagePatternUtil.cs
@@ -279,11 +279,7 @@ namespace ICU4N.Text
         }
         internal MessageNode Freeze()
         {
-#if FEATURE_ILIST_ASREADONLY
-            list = System.Collections.Generic.CollectionExtensions.AsReadOnly(list);
-#else
             list = list.AsReadOnly();
-#endif
             return this;
         }
 
@@ -609,11 +605,7 @@ namespace ICU4N.Text
         }
         internal ComplexArgStyleNode Freeze()
         {
-#if FEATURE_ILIST_ASREADONLY
-            list = System.Collections.Generic.CollectionExtensions.AsReadOnly(list);
-#else
             list = list.AsReadOnly();
-#endif
             return this;
         }
 

--- a/src/ICU4N/Util/Currency.cs
+++ b/src/ICU4N/Util/Currency.cs
@@ -1062,11 +1062,7 @@ namespace ICU4N.Util
                     //CurrencyFilter filter = CurrencyFilter.onDateRange(null, new Date(253373299200000L));
                     CurrencyFilter filter = CurrencyFilter.All;
                     IList<string> tenderCurrencies = GetTenderCurrencies(filter);
-#if FEATURE_ILIST_ASREADONLY
-                    all = System.Collections.Generic.CollectionExtensions.AsReadOnly(tenderCurrencies);
-#else
                     all = tenderCurrencies.AsReadOnly();
-#endif
 #if FEATURE_MICROSOFT_EXTENSIONS_CACHING
                     ALL_TENDER_CODES = new SoftReference<IList<string>>(all, new MemoryCacheEntryOptions { SlidingExpiration = SlidingExpiration });
 #else

--- a/src/ICU4N/Util/TimeUnit.cs
+++ b/src/ICU4N/Util/TimeUnit.cs
@@ -30,11 +30,7 @@ namespace ICU4N.Util
         }
 
         private static readonly IList<TimeUnit> values =
-#if FEATURE_ILIST_ASREADONLY
-            System.Collections.Generic.CollectionExtensions.AsReadOnly(new TimeUnit[] { Second, Minute, Hour, Day, Week, Month, Year });
-#else
             new TimeUnit[] { Second, Minute, Hour, Day, Week, Month, Year }.AsReadOnly();
-#endif
 
         /// <summary>
         /// Gets the available values.


### PR DESCRIPTION
Closes #139.

This adds a target and tests for `net10.0`, adds compatibility shims for `AsReadOnly()`, `Enum.GetValues<TEnum>()`, and `Enum.GetNames<TEnum>()`.