### PR TITLE
Replace LinkedHashSet<T> with OrderedHashSet<T>

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -2,7 +2,7 @@
   <PropertyGroup Label="NuGet Package Reference Versions">
     <IKVMMavenSdkPackageReferenceVersion>1.2.0</IKVMMavenSdkPackageReferenceVersion>
     <!-- J2N will break binary compatibility in 3.0.0 to fix the APIs of collection types -->
-    <J2NPackageReferenceVersion>[2.1.0, 3.0.0)</J2NPackageReferenceVersion>
+    <J2NPackageReferenceVersion>[2.2.0-alpha-0042, 3.0.0)</J2NPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion>6.0.2</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftExtensionsCachingMemoryPackageReferenceVersion Condition=" '$(TargetFramework)' == 'net451' ">1.1.2</MicrosoftExtensionsCachingMemoryPackageReferenceVersion>
     <MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>1.0.3</MicrosoftNETFrameworkReferenceAssembliesPackageReferenceVersion>

--- a/src/ICU4N.TestFramework/Dev/Test/TestBoilerplate.cs
+++ b/src/ICU4N.TestFramework/Dev/Test/TestBoilerplate.cs
@@ -179,7 +179,7 @@ namespace ICU4N.Dev.Test
         {
             if (values1 is JCG.SortedSet<T> s1 && s1.Equals(values2)) return true;
             else if (values1 is JCG.HashSet<T> h1 && h1.Equals(values2)) return true;
-            else if (values1 is JCG.LinkedHashSet<T> l1 && l1.Equals(values2)) return true;
+            else if (values1 is JCG.OrderedHashSet<T> o1 && o1.Equals(values2)) return true;
             else if (SetEqualityComparer<T>.Aggressive.Equals(values1, values2)) return true;
             else
             {

--- a/src/ICU4N/Impl/Locale/KeyTypeData.cs
+++ b/src/ICU4N/Impl/Locale/KeyTypeData.cs
@@ -271,7 +271,7 @@ namespace ICU4N.Impl.Locale
                         bcpKeyId = legacyKeyId;
                         hasSameKey = true;
                     }
-                    ISet<string> _bcp47Types = new JCG.LinkedHashSet<string>();
+                    ISet<string> _bcp47Types = new JCG.OrderedHashSet<string>();
                     _Bcp47Keys[bcpKeyId] = _bcp47Types.AsReadOnly();
 
                     bool isTZ = legacyKeyId.Equals("timezone");
@@ -519,7 +519,7 @@ namespace ICU4N.Impl.Locale
                 foreach (var keyInfoEntry2 in keyInfoEntry)
                 {
                     string key2 = keyInfoEntry2.Key;
-                    ISet<string> _deprecatedTypes = new JCG.LinkedHashSet<string>();
+                    ISet<string> _deprecatedTypes = new JCG.OrderedHashSet<string>();
                     foreach (var keyInfoEntry3 in keyInfoEntry2)
                     {
                         string key3 = keyInfoEntry3.Key;

--- a/src/ICU4N/Text/PluralRules.cs
+++ b/src/ICU4N/Text/PluralRules.cs
@@ -1227,7 +1227,7 @@ namespace ICU4N.Text
                 PluralRulesSampleType sampleType2;
                 bool bounded2 = true;
                 bool haveBound = false;
-                ISet<FixedDecimalRange> samples2 = new JCG.LinkedHashSet<FixedDecimalRange>();
+                ISet<FixedDecimalRange> samples2 = new JCG.OrderedHashSet<FixedDecimalRange>();
 
                 if (text.StartsWith("integer", StringComparison.Ordinal))
                 {

--- a/tests/ICU4N.Tests.Collation/Dev/Test/Util/ULocaleCollationTest.cs
+++ b/tests/ICU4N.Tests.Collation/Dev/Test/Util/ULocaleCollationTest.cs
@@ -337,7 +337,7 @@ namespace ICU4N.Dev.Test.Util
 
             foreach (String[][] test in tests)
             {
-                var list = new JCG.LinkedHashSet<UCultureInfo>();
+                var list = new JCG.OrderedHashSet<UCultureInfo>();
                 IList<UiListItem> expected = new JCG.List<UiListItem>();
                 foreach (String item in test[0])
                 {

--- a/tests/ICU4N.Tests/Dev/Test/Format/PluralFormatUnitTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Format/PluralFormatUnitTest.cs
@@ -215,7 +215,7 @@ namespace ICU4N.Dev.Test.Format
             foreach (UCultureInfo locale in PluralRules.GetUCultures())
             {
                 UCultureInfo otherLocale = PluralRules.GetFunctionalEquivalent(locale);
-                if (!same.TryGetValue(otherLocale, out ISet<UCultureInfo> others)) same[otherLocale] = others = new LinkedHashSet<UCultureInfo>();
+                if (!same.TryGetValue(otherLocale, out ISet<UCultureInfo> others)) same[otherLocale] = others = new J2N.Collections.Generic.OrderedHashSet<UCultureInfo>();
                 others.Add(locale);
                 continue;
             }

--- a/tests/ICU4N.Tests/Dev/Test/Format/PluralRulesTest.cs
+++ b/tests/ICU4N.Tests/Dev/Test/Format/PluralRulesTest.cs
@@ -372,7 +372,7 @@ namespace ICU4N.Dev.Test.Format
             {
                 PluralRules rules = factory.GetInstance(locale);
                 IDictionary<String, PluralRules> keywordToRule = new Dictionary<String, PluralRules>();
-                ICollection<FixedDecimalSamples> samples = new JCG.LinkedHashSet<FixedDecimalSamples>();
+                ICollection<FixedDecimalSamples> samples = new JCG.OrderedHashSet<FixedDecimalSamples>();
 
                 foreach (String keyword in rules.Keywords)
                 {
@@ -962,7 +962,7 @@ namespace ICU4N.Dev.Test.Format
         [Test]
         public void TestKeywords()
         {
-            ISet<string> possibleKeywords = new JCG.LinkedHashSet<string>(new string[] { "zero", "one", "two", "few", "many", "other" });
+            ISet<string> possibleKeywords = new JCG.OrderedHashSet<string>(new string[] { "zero", "one", "two", "few", "many", "other" });
             Object[][][] tests = new object[][][] {
                 // format is locale, explicits, then triples of keyword, status, unique value.
                 new object[][] { new object[] { "en", null }, new object[] { "one", PluralRulesKeywordStatus.Unique, 1.0d }, new object[] { "other", PluralRulesKeywordStatus.Unbounded, null } },
@@ -981,7 +981,7 @@ namespace ICU4N.Dev.Test.Format
                 // NumberType numberType = (NumberType) test[1];
                 ISet<double> explicits = (ISet<double>)test[0][1];
                 PluralRules pluralRules = factory.GetInstance(locale);
-                JCG.LinkedHashSet<string> remaining = new JCG.LinkedHashSet<string>(possibleKeywords);
+                JCG.OrderedHashSet<string> remaining = new JCG.OrderedHashSet<string>(possibleKeywords);
                 for (int i = 1; i < test.Length; ++i)
                 {
                     object[] row = test[i];


### PR DESCRIPTION
Issue: https://github.com/NightOwl888/ICU4N/issues/126

Swapped the `JCG.LinkedHashSet<T>` usages to `JCG.OrderedHashSet<T>` and bumped the J2N floor in `.build/dependencies.props` to `2.2.0-alpha-0042` (where `OrderedHashSet<T>` landed), same as the `OrderedDictionary` swap in #112.

Mostly a straight rename. Two spots needed a bit more: `TestBoilerplate.VerifySetsIdentical` had an explicit `is JCG.LinkedHashSet<T>` branch next to the `SortedSet`/`HashSet` ones, so I retargeted it to `OrderedHashSet<T>` to keep matching what the code produces now. `PluralFormatUnitTest` has no `JCG` alias, so I left `J2N.Collections.Generic.OrderedHashSet<T>` fully qualified to match the `LinkedDictionary` line beside it. Can alias that one too if you'd rather.

Built on net8.0 locally.
